### PR TITLE
feat: implement audit log module (#31)

### DIFF
--- a/src/domain/_031_audit_log/README.md
+++ b/src/domain/_031_audit_log/README.md
@@ -1,0 +1,35 @@
+# 031 Audit Log
+
+The Audit Log module provides an append-only ledger for critical system actions.
+It records who did what to which entity, along with the changes made in a structured format (JSON).
+
+## Usage Example
+
+### Create an Audit Log
+```python
+from src.domain._031_audit_log.schemas import AuditLogCreate
+from src.domain._031_audit_log.service import create_audit_log
+
+audit_data = AuditLogCreate(
+    action="UPDATE",
+    entity_name="User",
+    entity_id="123",
+    user_id="admin_1",
+    changes={"email": {"old": "a@b.com", "new": "b@c.com"}}
+)
+
+new_log = await create_audit_log(db_session, audit_data)
+```
+
+### Retrieve Audit Logs
+```python
+from src.domain._031_audit_log.service import get_audit_logs
+
+logs = await get_audit_logs(
+    db_session,
+    page=1,
+    page_size=10,
+    action="UPDATE",
+    entity_name="User"
+)
+```

--- a/src/domain/_031_audit_log/__init__.py
+++ b/src/domain/_031_audit_log/__init__.py
@@ -1,0 +1,16 @@
+"""
+Audit Log module for tracking critical system actions.
+"""
+from src.domain._031_audit_log.models import AuditLog
+from src.domain._031_audit_log.schemas import AuditLogCreate, AuditLogResponse
+from src.domain._031_audit_log.service import create_audit_log, get_audit_logs
+from src.domain._031_audit_log.router import router
+
+__all__ = [
+    "AuditLog",
+    "AuditLogCreate",
+    "AuditLogResponse",
+    "create_audit_log",
+    "get_audit_logs",
+    "router",
+]

--- a/src/domain/_031_audit_log/models.py
+++ b/src/domain/_031_audit_log/models.py
@@ -1,0 +1,26 @@
+"""
+SQLAlchemy models for the Audit Log module.
+"""
+from typing import Any
+from sqlalchemy import Integer, String, JSON, DateTime, func
+from sqlalchemy.orm import Mapped, mapped_column
+from datetime import datetime
+
+from shared.types import Base
+
+
+class AuditLog(Base):
+    """
+    AuditLog model to record critical actions across the system.
+    """
+    __tablename__ = "audit_log"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=func.now(), onupdate=func.now())
+
+    action: Mapped[str] = mapped_column(String(50), nullable=False)
+    entity_name: Mapped[str] = mapped_column(String(50), nullable=False)
+    entity_id: Mapped[str] = mapped_column(String(50), nullable=False)
+    user_id: Mapped[str] = mapped_column(String(50), nullable=False)
+    changes: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)

--- a/src/domain/_031_audit_log/router.py
+++ b/src/domain/_031_audit_log/router.py
@@ -1,0 +1,52 @@
+"""
+FastAPI router for the Audit Log module.
+"""
+from typing import Optional
+from fastapi import APIRouter, Depends, Query, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from shared.types import PaginatedResponse
+from src.foundation._001_database import get_db
+from src.domain._031_audit_log.schemas import AuditLogCreate, AuditLogResponse
+from src.domain._031_audit_log.service import create_audit_log, get_audit_logs
+
+router = APIRouter(
+    prefix="/api/v1/audit-log",
+    tags=["Audit Log"]
+)
+
+@router.post("", response_model=AuditLogResponse, status_code=201)
+async def create_audit_log_endpoint(
+    data: AuditLogCreate,
+    db: AsyncSession = Depends(get_db)
+):
+    """
+    Create a new audit log.
+    """
+    try:
+        return await create_audit_log(db, data)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+@router.get("", response_model=PaginatedResponse[AuditLogResponse])
+async def get_audit_logs_endpoint(
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=500),
+    action: Optional[str] = None,
+    entity_name: Optional[str] = None,
+    entity_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+    db: AsyncSession = Depends(get_db)
+):
+    """
+    Get paginated audit logs, optionally filtered.
+    """
+    return await get_audit_logs(
+        db=db,
+        page=page,
+        page_size=page_size,
+        action=action,
+        entity_name=entity_name,
+        entity_id=entity_id,
+        user_id=user_id
+    )

--- a/src/domain/_031_audit_log/schemas.py
+++ b/src/domain/_031_audit_log/schemas.py
@@ -1,0 +1,28 @@
+"""
+Pydantic schemas for the Audit Log module.
+"""
+from datetime import datetime
+from typing import Any
+
+from shared.types import BaseSchema
+
+
+class AuditLogCreate(BaseSchema):
+    """Schema for creating a new audit log."""
+    action: str
+    entity_name: str
+    entity_id: str
+    user_id: str
+    changes: dict[str, Any]
+
+
+class AuditLogResponse(BaseSchema):
+    """Schema for audit log response."""
+    id: int
+    created_at: datetime
+    updated_at: datetime
+    action: str
+    entity_name: str
+    entity_id: str
+    user_id: str
+    changes: dict[str, Any]

--- a/src/domain/_031_audit_log/service.py
+++ b/src/domain/_031_audit_log/service.py
@@ -1,0 +1,78 @@
+"""
+Service layer for the Audit Log module.
+"""
+from typing import Optional, Sequence
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, func
+
+from shared.types import PaginatedResponse
+from src.domain._031_audit_log.models import AuditLog
+from src.domain._031_audit_log.schemas import AuditLogCreate, AuditLogResponse
+from src.domain._031_audit_log.validators import validate_audit_log_create
+
+
+async def create_audit_log(db: AsyncSession, data: AuditLogCreate) -> AuditLogResponse:
+    """
+    Creates a new audit log entry.
+    """
+    validate_audit_log_create(data)
+
+    audit_log = AuditLog(
+        action=data.action,
+        entity_name=data.entity_name,
+        entity_id=data.entity_id,
+        user_id=data.user_id,
+        changes=data.changes
+    )
+    db.add(audit_log)
+    await db.commit()
+    await db.refresh(audit_log)
+
+    return AuditLogResponse.model_validate(audit_log)
+
+
+async def get_audit_logs(
+    db: AsyncSession,
+    page: int = 1,
+    page_size: int = 50,
+    action: Optional[str] = None,
+    entity_name: Optional[str] = None,
+    entity_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+) -> PaginatedResponse[AuditLogResponse]:
+    """
+    Retrieves a paginated list of audit logs, optionally filtered.
+    """
+    query = select(AuditLog)
+
+    if action:
+        query = query.where(AuditLog.action == action)
+    if entity_name:
+        query = query.where(AuditLog.entity_name == entity_name)
+    if entity_id:
+        query = query.where(AuditLog.entity_id == entity_id)
+    if user_id:
+        query = query.where(AuditLog.user_id == user_id)
+
+    # Count total
+    count_query = select(func.count()).select_from(query.subquery())
+    total_result = await db.execute(count_query)
+    total = total_result.scalar() or 0
+
+    # Pagination
+    query = query.order_by(AuditLog.created_at.desc())
+    query = query.offset((page - 1) * page_size).limit(page_size)
+
+    result = await db.execute(query)
+    logs = result.scalars().all()
+
+    items = [AuditLogResponse.model_validate(log) for log in logs]
+    total_pages = (total + page_size - 1) // page_size if page_size > 0 else 0
+
+    return PaginatedResponse(
+        items=items,
+        total=total,
+        page=page,
+        page_size=page_size,
+        total_pages=total_pages
+    )

--- a/src/domain/_031_audit_log/tests/test_models.py
+++ b/src/domain/_031_audit_log/tests/test_models.py
@@ -1,0 +1,18 @@
+import pytest
+from src.domain._031_audit_log.models import AuditLog
+
+def test_audit_log_initialization():
+    """Test that AuditLog can be initialized with correct fields."""
+    log = AuditLog(
+        action="CREATE",
+        entity_name="User",
+        entity_id="123",
+        user_id="admin_1",
+        changes={"name": "New User"}
+    )
+
+    assert log.action == "CREATE"
+    assert log.entity_name == "User"
+    assert log.entity_id == "123"
+    assert log.user_id == "admin_1"
+    assert log.changes == {"name": "New User"}

--- a/src/domain/_031_audit_log/tests/test_router.py
+++ b/src/domain/_031_audit_log/tests/test_router.py
@@ -1,0 +1,66 @@
+import pytest
+from unittest.mock import patch, AsyncMock
+from fastapi.testclient import TestClient
+from fastapi import FastAPI
+from src.domain._031_audit_log.router import router
+from src.domain._031_audit_log.schemas import AuditLogResponse
+from shared.types import PaginatedResponse
+
+app = FastAPI()
+app.include_router(router)
+client = TestClient(app)
+
+@patch("src.domain._031_audit_log.router.create_audit_log")
+def test_create_audit_log_endpoint(mock_create):
+    """Test POST /api/v1/audit-log endpoint."""
+    mock_create.return_value = AuditLogResponse(
+        id=1,
+        created_at="2023-01-01T00:00:00Z",
+        updated_at="2023-01-01T00:00:00Z",
+        action="DELETE",
+        entity_name="Order",
+        entity_id="789",
+        user_id="admin_3",
+        changes={"status": "cancelled"}
+    )
+
+    payload = {
+        "action": "DELETE",
+        "entity_name": "Order",
+        "entity_id": "789",
+        "user_id": "admin_3",
+        "changes": {"status": "cancelled"}
+    }
+
+    response = client.post("/api/v1/audit-log", json=payload)
+
+    assert response.status_code == 201
+    assert response.json()["action"] == "DELETE"
+
+@patch("src.domain._031_audit_log.router.get_audit_logs")
+def test_get_audit_logs_endpoint(mock_get):
+    """Test GET /api/v1/audit-log endpoint."""
+    mock_get.return_value = PaginatedResponse(
+        items=[
+            AuditLogResponse(
+                id=1,
+                created_at="2023-01-01T00:00:00Z",
+                updated_at="2023-01-01T00:00:00Z",
+                action="DELETE",
+                entity_name="Order",
+                entity_id="789",
+                user_id="admin_3",
+                changes={"status": "cancelled"}
+            )
+        ],
+        total=1,
+        page=1,
+        page_size=50,
+        total_pages=1
+    )
+
+    response = client.get("/api/v1/audit-log?page=1&page_size=50")
+
+    assert response.status_code == 200
+    assert response.json()["total"] == 1
+    assert len(response.json()["items"]) == 1

--- a/src/domain/_031_audit_log/tests/test_service.py
+++ b/src/domain/_031_audit_log/tests/test_service.py
@@ -1,0 +1,70 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from src.domain._031_audit_log.service import create_audit_log, get_audit_logs
+from src.domain._031_audit_log.schemas import AuditLogCreate
+
+@pytest.mark.asyncio
+async def test_create_audit_log():
+    """Test creation of an audit log entry."""
+    db_mock = AsyncMock()
+    db_mock.add = MagicMock()
+
+    data = AuditLogCreate(
+        action="CREATE",
+        entity_name="User",
+        entity_id="123",
+        user_id="admin_1",
+        changes={"name": "New User"}
+    )
+
+    # Mock behavior of db.refresh
+    async def mock_refresh(obj):
+        obj.id = 1
+        from datetime import datetime, timezone
+        obj.created_at = datetime.now(timezone.utc)
+        obj.updated_at = datetime.now(timezone.utc)
+
+    db_mock.refresh.side_effect = mock_refresh
+
+    response = await create_audit_log(db_mock, data)
+
+    db_mock.add.assert_called_once()
+    db_mock.commit.assert_awaited_once()
+    db_mock.refresh.assert_awaited_once()
+
+    assert response.action == "CREATE"
+    assert response.entity_name == "User"
+
+@pytest.mark.asyncio
+async def test_get_audit_logs():
+    """Test retrieving audit logs."""
+    db_mock = AsyncMock()
+
+    # Mock total count
+    count_result_mock = MagicMock()
+    count_result_mock.scalar.return_value = 1
+
+    # Mock data rows
+    from datetime import datetime, timezone
+    log_mock = MagicMock()
+    log_mock.id = 1
+    log_mock.created_at = datetime.now(timezone.utc)
+    log_mock.updated_at = datetime.now(timezone.utc)
+    log_mock.action = "UPDATE"
+    log_mock.entity_name = "Product"
+    log_mock.entity_id = "456"
+    log_mock.user_id = "admin_2"
+    log_mock.changes = {"price": 100}
+
+    data_result_mock = MagicMock()
+    data_result_mock.scalars().all.return_value = [log_mock]
+
+    # Sequence of returns for execute: first for count, second for data
+    db_mock.execute.side_effect = [count_result_mock, data_result_mock]
+
+    response = await get_audit_logs(db_mock, page=1, page_size=10, action="UPDATE")
+
+    assert response.total == 1
+    assert len(response.items) == 1
+    assert response.items[0].action == "UPDATE"
+    assert response.items[0].entity_name == "Product"

--- a/src/domain/_031_audit_log/tests/test_validators.py
+++ b/src/domain/_031_audit_log/tests/test_validators.py
@@ -1,0 +1,63 @@
+import pytest
+from src.domain._031_audit_log.schemas import AuditLogCreate
+from src.domain._031_audit_log.validators import validate_audit_log_create
+
+def test_validate_audit_log_create_valid():
+    """Test valid data passes validation."""
+    data = AuditLogCreate(
+        action="CREATE",
+        entity_name="User",
+        entity_id="123",
+        user_id="admin_1",
+        changes={"name": "New User"}
+    )
+    validated = validate_audit_log_create(data)
+    assert validated == data
+
+def test_validate_audit_log_create_empty_action():
+    """Test validation fails for empty action."""
+    data = AuditLogCreate(
+        action="  ",
+        entity_name="User",
+        entity_id="123",
+        user_id="admin_1",
+        changes={"name": "New User"}
+    )
+    with pytest.raises(ValueError, match="action cannot be empty"):
+        validate_audit_log_create(data)
+
+def test_validate_audit_log_create_empty_entity_name():
+    """Test validation fails for empty entity_name."""
+    data = AuditLogCreate(
+        action="CREATE",
+        entity_name="",
+        entity_id="123",
+        user_id="admin_1",
+        changes={"name": "New User"}
+    )
+    with pytest.raises(ValueError, match="entity_name cannot be empty"):
+        validate_audit_log_create(data)
+
+def test_validate_audit_log_create_empty_entity_id():
+    """Test validation fails for empty entity_id."""
+    data = AuditLogCreate(
+        action="CREATE",
+        entity_name="User",
+        entity_id="",
+        user_id="admin_1",
+        changes={"name": "New User"}
+    )
+    with pytest.raises(ValueError, match="entity_id cannot be empty"):
+        validate_audit_log_create(data)
+
+def test_validate_audit_log_create_empty_user_id():
+    """Test validation fails for empty user_id."""
+    data = AuditLogCreate(
+        action="CREATE",
+        entity_name="User",
+        entity_id="123",
+        user_id=" ",
+        changes={"name": "New User"}
+    )
+    with pytest.raises(ValueError, match="user_id cannot be empty"):
+        validate_audit_log_create(data)

--- a/src/domain/_031_audit_log/validators.py
+++ b/src/domain/_031_audit_log/validators.py
@@ -1,0 +1,20 @@
+"""
+Validators for the Audit Log module.
+"""
+from src.domain._031_audit_log.schemas import AuditLogCreate
+
+
+def validate_audit_log_create(data: AuditLogCreate) -> AuditLogCreate:
+    """
+    Validates the creation data for an audit log.
+    Ensures that required fields are not empty strings.
+    """
+    if not data.action.strip():
+        raise ValueError("action cannot be empty")
+    if not data.entity_name.strip():
+        raise ValueError("entity_name cannot be empty")
+    if not data.entity_id.strip():
+        raise ValueError("entity_id cannot be empty")
+    if not data.user_id.strip():
+        raise ValueError("user_id cannot be empty")
+    return data


### PR DESCRIPTION
Implement #31 by adding the `_031_audit_log` module. The module includes standard structures such as models, schemas, validators, services, routers, and comprehensive tests to ensure proper functionality and correct input validation. No main application integration is performed here since the repository currently focuses on module creation.

---
*PR created automatically by Jules for task [15882944918052101672](https://jules.google.com/task/15882944918052101672) started by @muumuu8181*