### PR TITLE
[Phase 1] 035 - Localization / i18n

### DIFF
--- a/src/domain/_035_localization/README.md
+++ b/src/domain/_035_localization/README.md
@@ -1,0 +1,18 @@
+# Localization / i18n Module (035)
+
+This module handles multi-language support across the ERP system.
+
+## Features
+- Locale management
+- Translation key-value store per module
+- Template-based lookup
+- Formatting utilities for dates, numbers, and currencies
+
+## Usage
+```python
+from src.domain._035_localization.service import format_date, format_number, format_currency
+
+# Format examples
+formatted_date = await format_date(db, "ja-JP", date.today())
+formatted_num = await format_number(db, "en-US", 1000.5)
+```

--- a/src/domain/_035_localization/__init__.py
+++ b/src/domain/_035_localization/__init__.py
@@ -1,0 +1,3 @@
+from src.domain._035_localization.router import router
+
+__all__ = ["router"]

--- a/src/domain/_035_localization/models.py
+++ b/src/domain/_035_localization/models.py
@@ -1,0 +1,32 @@
+from sqlalchemy import Integer, String, Boolean, Text, ForeignKey, UniqueConstraint, Index
+from sqlalchemy.orm import Mapped, mapped_column
+
+from shared.types import BaseModel
+
+
+class Locale(BaseModel):
+    __tablename__ = "locale"
+
+    code: Mapped[str] = mapped_column(String(5), unique=True, nullable=False)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    language: Mapped[str] = mapped_column(String(10), nullable=False)
+    country: Mapped[str] = mapped_column(String(10), nullable=False)
+    date_format: Mapped[str] = mapped_column(String(20), nullable=False)
+    number_format: Mapped[str] = mapped_column(String(20), nullable=False)
+    currency_code: Mapped[str] = mapped_column(String(3), nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+
+
+class Translation(BaseModel):
+    __tablename__ = "translation"
+
+    locale_id: Mapped[int] = mapped_column(Integer, ForeignKey("locale.id"), nullable=False)
+    module: Mapped[str] = mapped_column(String(50), nullable=False)
+    key: Mapped[str] = mapped_column(String(200), nullable=False)
+    value: Mapped[str] = mapped_column(Text, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("locale_id", "module", "key", name="uq_translation_locale_module_key"),
+        Index("ix_translation_locale_id", "locale_id"),
+        Index("ix_translation_module", "module"),
+    )

--- a/src/domain/_035_localization/router.py
+++ b/src/domain/_035_localization/router.py
@@ -1,0 +1,122 @@
+from datetime import datetime
+from typing import Optional, List
+
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.foundation._001_database.engine import get_db
+from src.domain._035_localization import service
+from src.domain._035_localization.schemas import (
+    LocaleCreate,
+    LocaleResponse,
+    TranslationCreate,
+    TranslationResponse,
+    TranslationLookup,
+    LocalizationExport,
+    FormatDateRequest,
+    FormatNumberRequest,
+    FormatCurrencyRequest,
+    ImportTranslationsRequest,
+    ImportTranslationsResponse
+)
+
+
+router = APIRouter(prefix="/api/v1/localization", tags=["localization"])
+
+
+@router.post("/locales", response_model=LocaleResponse, status_code=status.HTTP_201_CREATED)
+async def create_locale(
+    data: LocaleCreate,
+    db: AsyncSession = Depends(get_db)
+) -> LocaleResponse:
+    """Create a new locale."""
+    return await service.create_locale(db, data)
+
+
+@router.get("/locales", response_model=List[LocaleResponse])
+async def list_locales(
+    is_active: Optional[bool] = Query(None),
+    db: AsyncSession = Depends(get_db)
+) -> List[LocaleResponse]:
+    """List locales."""
+    return await service.list_locales(db, is_active=is_active)
+
+
+@router.post("/translations", response_model=TranslationResponse, status_code=status.HTTP_201_CREATED)
+async def add_translation(
+    data: TranslationCreate,
+    db: AsyncSession = Depends(get_db)
+) -> TranslationResponse:
+    """Add a translation entry."""
+    return await service.add_translation(db, data)
+
+
+@router.get("/translations", response_model=List[TranslationResponse])
+async def get_translations(
+    locale: str = Query(..., description="Locale code"),
+    module: Optional[str] = Query(None, description="Module filter"),
+    db: AsyncSession = Depends(get_db)
+) -> List[TranslationResponse]:
+    """Get translations for a locale, optionally filtered by module."""
+    return await service.get_translations(db, locale_code=locale, module=module)
+
+
+@router.post("/translations/lookup")
+async def lookup_translation(
+    data: TranslationLookup,
+    db: AsyncSession = Depends(get_db)
+) -> str:
+    """Look up a single translation by key."""
+    return await service.translate(db, data.locale_code, data.key or "", data.default)
+
+
+@router.post("/format-date")
+async def format_date_endpoint(
+    data: FormatDateRequest,
+    db: AsyncSession = Depends(get_db)
+) -> str:
+    """Format a date according to locale settings."""
+    try:
+        # Try to parse string as date for simplicity in API (YYYY-MM-DD)
+        dt = datetime.strptime(data.value, "%Y-%m-%d").date()
+    except ValueError:
+        return data.value # Fallback if not YYYY-MM-DD
+    return await service.format_date(db, data.locale_code, dt)
+
+
+@router.post("/format-number")
+async def format_number_endpoint(
+    data: FormatNumberRequest,
+    db: AsyncSession = Depends(get_db)
+) -> str:
+    """Format a number according to locale settings."""
+    return await service.format_number(db, data.locale_code, data.value)
+
+
+@router.post("/format-currency")
+async def format_currency_endpoint(
+    data: FormatCurrencyRequest,
+    db: AsyncSession = Depends(get_db)
+) -> str:
+    """Format a currency value according to locale settings."""
+    return await service.format_currency(db, data.locale_code, data.value)
+
+
+@router.post("/translations/export", response_model=LocalizationExport)
+async def export_translations_endpoint(
+    locale_code: str = Query(..., description="Locale code"),
+    module: Optional[str] = Query(None, description="Module filter"),
+    db: AsyncSession = Depends(get_db)
+) -> LocalizationExport:
+    """Export translations as JSON."""
+    return await service.export_translations(db, locale_code, module)
+
+
+@router.post("/translations/import", response_model=ImportTranslationsResponse)
+async def import_translations_endpoint(
+    data: ImportTranslationsRequest,
+    db: AsyncSession = Depends(get_db)
+) -> ImportTranslationsResponse:
+    """Import translations from JSON."""
+    count = await service.import_translations(db, data.locale_code, data.translations, data.module)
+    return ImportTranslationsResponse(imported_count=count)

--- a/src/domain/_035_localization/schemas.py
+++ b/src/domain/_035_localization/schemas.py
@@ -1,0 +1,73 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import Field
+
+from shared.types import BaseSchema
+
+
+class LocaleCreate(BaseSchema):
+    code: str = Field(..., max_length=5)
+    name: str = Field(..., max_length=100)
+    language: str = Field(..., max_length=10)
+    country: str = Field(..., max_length=10)
+    date_format: str = Field(..., max_length=20)
+    number_format: str = Field(..., max_length=20)
+    currency_code: str = Field(..., max_length=3)
+    is_active: bool = True
+
+
+class LocaleResponse(LocaleCreate):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class TranslationCreate(BaseSchema):
+    locale_id: int
+    module: str = Field(..., max_length=50)
+    key: str = Field(..., max_length=200)
+    value: str
+
+
+class TranslationResponse(TranslationCreate):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class TranslationLookup(BaseSchema):
+    locale_code: str
+    module: Optional[str] = None
+    key: Optional[str] = None
+    default: Optional[str] = None
+
+
+class LocalizationExport(BaseSchema):
+    locale_code: str
+    translations: dict[str, str]
+
+
+class FormatDateRequest(BaseSchema):
+    locale_code: str
+    value: str
+
+
+class FormatNumberRequest(BaseSchema):
+    locale_code: str
+    value: float
+
+
+class FormatCurrencyRequest(BaseSchema):
+    locale_code: str
+    value: float
+
+
+class ImportTranslationsRequest(BaseSchema):
+    locale_code: str
+    module: str
+    translations: dict[str, str]
+
+
+class ImportTranslationsResponse(BaseSchema):
+    imported_count: int

--- a/src/domain/_035_localization/service.py
+++ b/src/domain/_035_localization/service.py
@@ -1,0 +1,209 @@
+from datetime import date
+from typing import Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from shared.errors import NotFoundError
+from src.domain._035_localization.models import Locale, Translation
+from src.domain._035_localization.schemas import (
+    LocaleCreate,
+    TranslationCreate,
+    LocalizationExport,
+)
+from src.domain._035_localization.validators import (
+    validate_locale_create,
+    validate_translation_create,
+)
+
+
+async def create_locale(db: AsyncSession, data: LocaleCreate) -> Locale:
+    """Create a new locale. Validates code format (xx-XX)."""
+    await validate_locale_create(db, data)
+    locale = Locale(**data.model_dump())
+    db.add(locale)
+    await db.commit()
+    await db.refresh(locale)
+    return locale
+
+
+async def list_locales(db: AsyncSession, is_active: Optional[bool] = None) -> list[Locale]:
+    """List all locales, optionally filtered by active status."""
+    query = select(Locale)
+    if is_active is not None:
+        query = query.filter(Locale.is_active == is_active)
+    result = await db.execute(query)
+    return list(result.scalars().all())
+
+
+async def add_translation(db: AsyncSession, data: TranslationCreate) -> Translation:
+    """Add a translation entry. Validates key format and value not empty."""
+    await validate_translation_create(db, data)
+    translation = Translation(**data.model_dump())
+    db.add(translation)
+    await db.commit()
+    await db.refresh(translation)
+    return translation
+
+
+async def get_translations(db: AsyncSession, locale_code: str, module: Optional[str] = None) -> list[Translation]:
+    """Get translations for a locale, optionally filtered by module."""
+    locale = await _get_locale_by_code(db, locale_code)
+    query = select(Translation).filter(Translation.locale_id == locale.id)
+    if module:
+        query = query.filter(Translation.module == module)
+    result = await db.execute(query)
+    return list(result.scalars().all())
+
+
+async def get_translations_by_module(db: AsyncSession, locale_code: str, module: str) -> dict[str, str]:
+    """Get translations as a key-value dict for a specific locale and module."""
+    translations = await get_translations(db, locale_code, module)
+    return {t.key: t.value for t in translations}
+
+
+async def translate(db: AsyncSession, locale_code: str, key: str, default: Optional[str] = None) -> str:
+    """Look up a single translation by key. Returns default or key if not found."""
+    try:
+        locale = await _get_locale_by_code(db, locale_code)
+    except NotFoundError:
+        return default if default is not None else key
+
+    result = await db.execute(
+        select(Translation).filter(
+            Translation.locale_id == locale.id,
+            Translation.key == key
+        )
+    )
+    translation = result.scalars().first()
+    if translation:
+        return str(translation.value)
+    return default if default is not None else key
+
+
+async def format_date(db: AsyncSession, locale_code: str, value: date) -> str:
+    """Format a date according to locale settings."""
+    locale = await _get_locale_by_code(db, locale_code)
+    return value.strftime(locale.date_format)
+
+
+async def format_number(db: AsyncSession, locale_code: str, value: float) -> str:
+    """Format a number according to locale settings (thousands separator, decimal)."""
+    locale = await _get_locale_by_code(db, locale_code)
+
+    fmt = locale.number_format
+    if fmt == "#,###":
+        return f"{int(value):,}"
+    elif fmt == "#,###.##":
+        # Format with commas and up to 2 decimal places, removing trailing zeros after decimal
+        formatted = f"{value:,.2f}"
+        if formatted.endswith(".00"):
+            return formatted[:-3]
+        if formatted[-1] == "0" and "." in formatted:
+            return formatted[:-1]
+        return formatted
+
+    # Fallback to simple formatting
+    return f"{value}"
+
+
+async def format_currency(db: AsyncSession, locale_code: str, value: float) -> str:
+    """Format a currency value according to locale settings (symbol, decimals)."""
+    locale = await _get_locale_by_code(db, locale_code)
+
+    # Basic logic for specific currencies
+    if locale.currency_code == "JPY":
+        return f"¥{int(value):,}"
+    elif locale.currency_code == "USD":
+        return f"${value:,.2f}"
+
+    # Generic format using number formatter
+    num_str = await format_number(db, locale_code, value)
+    return f"{num_str} {locale.currency_code}"
+
+
+async def export_translations(db: AsyncSession, locale_code: str, module: Optional[str] = None) -> LocalizationExport:
+    """Export translations as JSON-serializable dict."""
+    translations_list = await get_translations(db, locale_code, module)
+    translations_dict = {t.key: t.value for t in translations_list}
+    return LocalizationExport(locale_code=locale_code, translations=translations_dict)
+
+
+async def import_translations(db: AsyncSession, locale_code: str, data: dict[str, str], module: str) -> int:
+    """Import translations from a key-value dict. Upserts existing entries.
+    Returns count of imported/updated translations.
+    """
+    locale = await _get_locale_by_code(db, locale_code)
+
+    count = 0
+    for key, value in data.items():
+        # Validate key
+        from src.domain._035_localization.validators import KEY_PATTERN
+        if not KEY_PATTERN.match(key):
+            continue # skip invalid keys
+
+        result = await db.execute(
+            select(Translation).filter(
+                Translation.locale_id == locale.id,
+                Translation.module == module,
+                Translation.key == key
+            )
+        )
+        existing = result.scalars().first()
+
+        if existing:
+            existing.value = value
+        else:
+            new_trans = Translation(
+                locale_id=locale.id,
+                module=module,
+                key=key,
+                value=value
+            )
+            db.add(new_trans)
+        count += 1
+
+    await db.commit()
+    return count
+
+
+async def _get_locale_by_code(db: AsyncSession, code: str) -> Locale:
+    result = await db.execute(select(Locale).filter(Locale.code == code))
+    locale = result.scalars().first()
+    if not locale:
+        raise NotFoundError(f"Locale with code {code} not found.")
+    return locale
+
+
+async def seed_default_locales(db: AsyncSession) -> None:
+    """Seed default locales if they don't exist."""
+    locales_to_seed = [
+        LocaleCreate(
+            code="ja-JP",
+            name="日本語",
+            language="ja",
+            country="JP",
+            date_format="%Y年%m月%d日",
+            number_format="#,###",
+            currency_code="JPY",
+            is_active=True
+        ),
+        LocaleCreate(
+            code="en-US",
+            name="English",
+            language="en",
+            country="US",
+            date_format="%m/%d/%Y",
+            number_format="#,###.##",
+            currency_code="USD",
+            is_active=True
+        )
+    ]
+
+    for data in locales_to_seed:
+        result = await db.execute(select(Locale).filter(Locale.code == data.code))
+        if not result.scalars().first():
+            locale = Locale(**data.model_dump())
+            db.add(locale)
+
+    await db.commit()

--- a/src/domain/_035_localization/tests/conftest.py
+++ b/src/domain/_035_localization/tests/conftest.py
@@ -1,0 +1,40 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy.ext.asyncio import AsyncSession
+from fastapi import FastAPI
+from src.foundation._001_database.engine import create_engine, get_session_factory, get_db
+from src.domain._035_localization.router import router
+from shared.types import Base
+
+# Setup in-memory sqlite
+test_engine = create_engine("sqlite+aiosqlite:///:memory:", echo=False)
+session_factory = get_session_factory(test_engine)
+
+@pytest.fixture(autouse=True)
+async def init_db():
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+@pytest.fixture
+async def db_session():
+    async with session_factory() as session:
+        yield session
+
+@pytest.fixture
+def app():
+    app = FastAPI()
+    app.include_router(router)
+    # Override db
+    async def override_get_db():
+        async with session_factory() as session:
+            yield session
+    app.dependency_overrides[get_db] = override_get_db
+    return app
+
+@pytest.fixture
+async def client(app):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        yield client

--- a/src/domain/_035_localization/tests/test_models.py
+++ b/src/domain/_035_localization/tests/test_models.py
@@ -1,0 +1,118 @@
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.domain._035_localization.models import Locale, Translation
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_locale_model_creation(db_session: AsyncSession):
+    locale = Locale(
+        code="fr-FR",
+        name="Français",
+        language="fr",
+        country="FR",
+        date_format="%d/%m/%Y",
+        number_format="#,###.##",
+        currency_code="EUR"
+    )
+    db_session.add(locale)
+    await db_session.commit()
+
+    result = await db_session.execute(select(Locale).filter(Locale.code == "fr-FR"))
+    fetched = result.scalars().first()
+    assert fetched is not None
+    assert fetched.name == "Français"
+
+
+async def test_locale_model_unique_code(db_session: AsyncSession):
+    locale1 = Locale(
+        code="it-IT",
+        name="Italiano",
+        language="it",
+        country="IT",
+        date_format="%d/%m/%Y",
+        number_format="#,###.##",
+        currency_code="EUR"
+    )
+    locale2 = Locale(
+        code="it-IT",
+        name="Italiano 2",
+        language="it",
+        country="IT",
+        date_format="%d/%m/%Y",
+        number_format="#,###.##",
+        currency_code="EUR"
+    )
+    db_session.add(locale1)
+    await db_session.commit()
+
+    db_session.add(locale2)
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+    await db_session.rollback()
+
+
+async def test_translation_model_creation(db_session: AsyncSession):
+    locale = Locale(
+        code="de-DE",
+        name="Deutsch",
+        language="de",
+        country="DE",
+        date_format="%d.%m.%Y",
+        number_format="#,###.##",
+        currency_code="EUR"
+    )
+    db_session.add(locale)
+    await db_session.commit()
+
+    translation = Translation(
+        locale_id=locale.id,
+        module="invoice",
+        key="invoice.title.main",
+        value="Rechnung"
+    )
+    db_session.add(translation)
+    await db_session.commit()
+
+    result = await db_session.execute(select(Translation).filter(Translation.key == "invoice.title.main"))
+    fetched = result.scalars().first()
+    assert fetched is not None
+    assert fetched.value == "Rechnung"
+
+
+async def test_translation_unique_constraint(db_session: AsyncSession):
+    locale = Locale(
+        code="es-ES",
+        name="Español",
+        language="es",
+        country="ES",
+        date_format="%d/%m/%Y",
+        number_format="#,###.##",
+        currency_code="EUR"
+    )
+    db_session.add(locale)
+    await db_session.commit()
+
+    trans1 = Translation(
+        locale_id=locale.id,
+        module="common",
+        key="common.button.save",
+        value="Guardar"
+    )
+    trans2 = Translation(
+        locale_id=locale.id,
+        module="common",
+        key="common.button.save",
+        value="Save"
+    )
+
+    db_session.add(trans1)
+    await db_session.commit()
+
+    db_session.add(trans2)
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+    await db_session.rollback()

--- a/src/domain/_035_localization/tests/test_router.py
+++ b/src/domain/_035_localization/tests/test_router.py
@@ -1,0 +1,132 @@
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.domain._035_localization.service import seed_default_locales
+from src.domain._035_localization.models import Locale
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+async def seeded_db_router(db_session: AsyncSession):
+    await seed_default_locales(db_session)
+    return db_session
+
+
+async def test_create_locale(client: AsyncClient, seeded_db_router: AsyncSession):
+    data = {
+        "code": "fr-FR",
+        "name": "Français",
+        "language": "fr",
+        "country": "FR",
+        "date_format": "%d/%m/%Y",
+        "number_format": "#,###.##",
+        "currency_code": "EUR"
+    }
+    response = await client.post("/api/v1/localization/locales", json=data)
+    assert response.status_code == 201
+    assert response.json()["code"] == "fr-FR"
+
+
+async def test_list_locales(client: AsyncClient, seeded_db_router: AsyncSession):
+    response = await client.get("/api/v1/localization/locales")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) >= 2
+
+
+async def test_add_translation(client: AsyncClient, seeded_db_router: AsyncSession):
+    # Need to get a locale ID first
+    resp = await client.get("/api/v1/localization/locales")
+    locales = resp.json()
+    ja_id = next(l["id"] for l in locales if l["code"] == "ja-JP")
+
+    data = {
+        "locale_id": ja_id,
+        "module": "invoice",
+        "key": "invoice.title.main",
+        "value": "請求書"
+    }
+    response = await client.post("/api/v1/localization/translations", json=data)
+    assert response.status_code == 201
+    assert response.json()["value"] == "請求書"
+
+
+async def test_get_translations(client: AsyncClient, seeded_db_router: AsyncSession):
+    # Seed a translation
+    resp = await client.get("/api/v1/localization/locales")
+    locales = resp.json()
+    ja_id = next(l["id"] for l in locales if l["code"] == "ja-JP")
+
+    await client.post("/api/v1/localization/translations", json={
+        "locale_id": ja_id,
+        "module": "invoice",
+        "key": "invoice.title.main",
+        "value": "請求書"
+    })
+
+    response = await client.get("/api/v1/localization/translations?locale=ja-JP&module=invoice")
+    assert response.status_code == 200
+    assert len(response.json()) >= 1
+
+
+async def test_lookup_translation(client: AsyncClient, seeded_db_router: AsyncSession):
+    data = {
+        "locale_code": "ja-JP",
+        "key": "invoice.title.main",
+        "default": "Invoice"
+    }
+    response = await client.post("/api/v1/localization/translations/lookup", json=data)
+    assert response.status_code == 200
+    assert response.json() == "Invoice" # Since it doesn't exist yet, it returns default
+
+
+async def test_format_date(client: AsyncClient, seeded_db_router: AsyncSession):
+    data = {
+        "locale_code": "ja-JP",
+        "value": "2025-01-15"
+    }
+    response = await client.post("/api/v1/localization/format-date", json=data)
+    assert response.status_code == 200
+    assert response.json() == "2025年01月15日"
+
+
+async def test_format_number(client: AsyncClient, seeded_db_router: AsyncSession):
+    data = {
+        "locale_code": "ja-JP",
+        "value": 1234567.89
+    }
+    response = await client.post("/api/v1/localization/format-number", json=data)
+    assert response.status_code == 200
+    assert response.json() == "1,234,567"
+
+
+async def test_format_currency(client: AsyncClient, seeded_db_router: AsyncSession):
+    data = {
+        "locale_code": "ja-JP",
+        "value": 100000
+    }
+    response = await client.post("/api/v1/localization/format-currency", json=data)
+    assert response.status_code == 200
+    assert response.json() == "¥100,000"
+
+
+async def test_export_translations(client: AsyncClient, seeded_db_router: AsyncSession):
+    response = await client.post("/api/v1/localization/translations/export?locale_code=ja-JP&module=invoice")
+    assert response.status_code == 200
+    assert "translations" in response.json()
+
+
+async def test_import_translations(client: AsyncClient, seeded_db_router: AsyncSession):
+    data = {
+        "locale_code": "ja-JP",
+        "module": "invoice",
+        "translations": {
+            "invoice.title.main": "請求書",
+            "invoice.label.date": "日付"
+        }
+    }
+    response = await client.post("/api/v1/localization/translations/import", json=data)
+    assert response.status_code == 200
+    assert response.json()["imported_count"] == 2

--- a/src/domain/_035_localization/tests/test_service.py
+++ b/src/domain/_035_localization/tests/test_service.py
@@ -1,0 +1,179 @@
+import pytest
+from datetime import date
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from shared.errors import ValidationError, DuplicateError, NotFoundError
+from src.domain._035_localization.models import Locale, Translation
+from src.domain._035_localization.schemas import LocaleCreate, TranslationCreate
+from src.domain._035_localization.service import (
+    create_locale, list_locales, add_translation, get_translations,
+    get_translations_by_module, translate, format_date, format_number,
+    format_currency, export_translations, import_translations, seed_default_locales
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+async def seeded_db(db_session: AsyncSession):
+    await seed_default_locales(db_session)
+    return db_session
+
+
+async def test_create_locale_success(db_session: AsyncSession):
+    data = LocaleCreate(
+        code="fr-FR", name="Français", language="fr", country="FR",
+        date_format="%d/%m/%Y", number_format="#,###.##", currency_code="EUR"
+    )
+    locale = await create_locale(db_session, data)
+    assert locale.id is not None
+    assert locale.code == "fr-FR"
+
+
+async def test_list_locales(seeded_db: AsyncSession):
+    locales = await list_locales(seeded_db)
+    assert len(locales) >= 2
+    codes = [l.code for l in locales]
+    assert "ja-JP" in codes
+    assert "en-US" in codes
+
+    active_locales = await list_locales(seeded_db, is_active=True)
+    assert len(active_locales) == len(locales)
+
+
+async def test_add_translation(seeded_db: AsyncSession):
+    locales = await list_locales(seeded_db)
+    ja_locale = next(l for l in locales if l.code == "ja-JP")
+
+    data = TranslationCreate(
+        locale_id=ja_locale.id, module="invoice", key="invoice.title.main", value="請求書"
+    )
+    trans = await add_translation(seeded_db, data)
+    assert trans.id is not None
+    assert trans.value == "請求書"
+
+
+async def test_get_translations(seeded_db: AsyncSession):
+    locales = await list_locales(seeded_db)
+    en_locale = next(l for l in locales if l.code == "en-US")
+
+    await add_translation(seeded_db, TranslationCreate(
+        locale_id=en_locale.id, module="common", key="common.button.save", value="Save"
+    ))
+    await add_translation(seeded_db, TranslationCreate(
+        locale_id=en_locale.id, module="invoice", key="invoice.title.main", value="Invoice"
+    ))
+
+    # All for locale
+    all_trans = await get_translations(seeded_db, "en-US")
+    assert len(all_trans) == 2
+
+    # Filtered by module
+    invoice_trans = await get_translations(seeded_db, "en-US", module="invoice")
+    assert len(invoice_trans) == 1
+    assert invoice_trans[0].value == "Invoice"
+
+
+async def test_get_translations_by_module(seeded_db: AsyncSession):
+    locales = await list_locales(seeded_db)
+    ja_locale = next(l for l in locales if l.code == "ja-JP")
+
+    await add_translation(seeded_db, TranslationCreate(
+        locale_id=ja_locale.id, module="common", key="common.button.save", value="保存"
+    ))
+
+    dict_trans = await get_translations_by_module(seeded_db, "ja-JP", "common")
+    assert "common.button.save" in dict_trans
+    assert dict_trans["common.button.save"] == "保存"
+
+
+async def test_translate(seeded_db: AsyncSession):
+    locales = await list_locales(seeded_db)
+    ja_locale = next(l for l in locales if l.code == "ja-JP")
+
+    await add_translation(seeded_db, TranslationCreate(
+        locale_id=ja_locale.id, module="common", key="common.msg.success", value="成功"
+    ))
+
+    # Existing
+    val = await translate(seeded_db, "ja-JP", "common.msg.success")
+    assert val == "成功"
+
+    # Missing with default
+    val2 = await translate(seeded_db, "ja-JP", "common.msg.error", default="Error")
+    assert val2 == "Error"
+
+    # Missing without default
+    val3 = await translate(seeded_db, "ja-JP", "common.msg.warning")
+    assert val3 == "common.msg.warning"
+
+    # Missing locale
+    val4 = await translate(seeded_db, "fr-FR", "common.msg.success", default="Success")
+    assert val4 == "Success"
+
+
+async def test_format_date(seeded_db: AsyncSession):
+    dt = date(2025, 1, 15)
+
+    ja_date = await format_date(seeded_db, "ja-JP", dt)
+    assert ja_date == "2025年01月15日"
+
+    en_date = await format_date(seeded_db, "en-US", dt)
+    assert en_date == "01/15/2025"
+
+
+async def test_format_number(seeded_db: AsyncSession):
+    val = 1234567.89
+
+    ja_num = await format_number(seeded_db, "ja-JP", val)
+    assert ja_num == "1,234,567"
+
+    en_num = await format_number(seeded_db, "en-US", val)
+    assert en_num == "1,234,567.89"
+
+
+async def test_format_currency(seeded_db: AsyncSession):
+    val = 100000.50
+
+    ja_curr = await format_currency(seeded_db, "ja-JP", val)
+    assert ja_curr == "¥100,000"
+
+    en_curr = await format_currency(seeded_db, "en-US", val)
+    assert en_curr == "$100,000.50"
+
+
+async def test_export_translations(seeded_db: AsyncSession):
+    locales = await list_locales(seeded_db)
+    ja_locale = next(l for l in locales if l.code == "ja-JP")
+
+    await add_translation(seeded_db, TranslationCreate(
+        locale_id=ja_locale.id, module="invoice", key="invoice.title.main", value="請求書"
+    ))
+
+    export = await export_translations(seeded_db, "ja-JP", module="invoice")
+    assert export.locale_code == "ja-JP"
+    assert export.translations["invoice.title.main"] == "請求書"
+
+
+async def test_import_translations(seeded_db: AsyncSession):
+    data = {
+        "invoice.title.main": "Invoice",
+        "invoice.button.send": "Send"
+    }
+
+    count = await import_translations(seeded_db, "en-US", data, "invoice")
+    assert count == 2
+
+    # Upsert test
+    data_update = {
+        "invoice.title.main": "Tax Invoice",
+        "invoice.label.date": "Date"
+    }
+    count2 = await import_translations(seeded_db, "en-US", data_update, "invoice")
+    assert count2 == 2
+
+    dict_trans = await get_translations_by_module(seeded_db, "en-US", "invoice")
+    assert dict_trans["invoice.title.main"] == "Tax Invoice"
+    assert dict_trans["invoice.button.send"] == "Send"
+    assert dict_trans["invoice.label.date"] == "Date"

--- a/src/domain/_035_localization/tests/test_validators.py
+++ b/src/domain/_035_localization/tests/test_validators.py
@@ -1,0 +1,90 @@
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from shared.errors import ValidationError, DuplicateError
+from src.domain._035_localization.validators import validate_locale_create, validate_translation_create
+from src.domain._035_localization.schemas import LocaleCreate, TranslationCreate
+from src.domain._035_localization.models import Locale, Translation
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_locale_code_format(db_session: AsyncSession):
+    # Pass
+    data = LocaleCreate(
+        code="ja-JP", name="Japanese", language="ja", country="JP",
+        date_format="%Y", number_format="#", currency_code="JPY"
+    )
+    await validate_locale_create(db_session, data)
+
+    # Fail
+    invalid_codes = ["japanese", "JA-jp", "jJP", "ja_JP"]
+    for code in invalid_codes:
+        data.code = code
+        with pytest.raises(ValidationError):
+            await validate_locale_create(db_session, data)
+
+
+async def test_locale_currency_code_format(db_session: AsyncSession):
+    # Pass
+    data = LocaleCreate(
+        code="ja-JP", name="Japanese", language="ja", country="JP",
+        date_format="%Y", number_format="#", currency_code="JPY"
+    )
+    await validate_locale_create(db_session, data)
+
+    # Fail
+    invalid_codes = ["jp", "JP", "Jpy", "123"]
+    for code in invalid_codes:
+        data.currency_code = code
+        with pytest.raises(ValidationError):
+            await validate_locale_create(db_session, data)
+
+
+async def test_locale_duplicate_code(db_session: AsyncSession):
+    locale = Locale(
+        code="ja-JP", name="Japanese", language="ja", country="JP",
+        date_format="%Y", number_format="#", currency_code="JPY"
+    )
+    db_session.add(locale)
+    await db_session.commit()
+
+    data = LocaleCreate(
+        code="ja-JP", name="Another", language="ja", country="JP",
+        date_format="%Y", number_format="#", currency_code="JPY"
+    )
+    with pytest.raises(DuplicateError):
+        await validate_locale_create(db_session, data)
+
+
+async def test_translation_key_format(db_session: AsyncSession):
+    # Pass
+    data = TranslationCreate(locale_id=1, module="invoice", key="invoice.title.main", value="Test")
+    await validate_translation_create(db_session, data)
+
+    # Fail
+    invalid_keys = ["Invoice", "invoice.title", "INV.TITLE.MAIN", "invoice.title.main.sub"]
+    for key in invalid_keys:
+        data.key = key
+        with pytest.raises(ValidationError):
+            await validate_translation_create(db_session, data)
+
+
+async def test_translation_value_not_empty(db_session: AsyncSession):
+    data = TranslationCreate(locale_id=1, module="invoice", key="invoice.title.main", value="")
+    with pytest.raises(ValidationError):
+        await validate_translation_create(db_session, data)
+
+    data.value = "   "
+    with pytest.raises(ValidationError):
+        await validate_translation_create(db_session, data)
+
+
+async def test_translation_duplicate(db_session: AsyncSession):
+    trans = Translation(locale_id=1, module="invoice", key="invoice.title.main", value="Original")
+    db_session.add(trans)
+    await db_session.commit()
+
+    data = TranslationCreate(locale_id=1, module="invoice", key="invoice.title.main", value="New")
+    with pytest.raises(DuplicateError):
+        await validate_translation_create(db_session, data)

--- a/src/domain/_035_localization/validators.py
+++ b/src/domain/_035_localization/validators.py
@@ -1,0 +1,43 @@
+import re
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from shared.errors import ValidationError, DuplicateError
+from src.domain._035_localization.schemas import LocaleCreate, TranslationCreate
+from src.domain._035_localization.models import Locale, Translation
+
+
+LOCALE_CODE_PATTERN = re.compile(r"^[a-z]{2}-[A-Z]{2}$")
+KEY_PATTERN = re.compile(r"^[a-z_]+\.[a-z_]+\.[a-z_]+$")
+CURRENCY_CODE_PATTERN = re.compile(r"^[A-Z]{3}$")
+
+
+async def validate_locale_create(db: AsyncSession, data: LocaleCreate) -> None:
+    if not LOCALE_CODE_PATTERN.match(data.code):
+        raise ValidationError(f"Invalid locale code format: {data.code}. Expected format: xx-XX")
+
+    if not CURRENCY_CODE_PATTERN.match(data.currency_code):
+        raise ValidationError(f"Invalid currency code format: {data.currency_code}. Expected 3 uppercase letters.")
+
+    result = await db.execute(select(Locale).filter(Locale.code == data.code))
+    if result.scalars().first():
+        raise DuplicateError(f"Locale with code {data.code} already exists.")
+
+
+async def validate_translation_create(db: AsyncSession, data: TranslationCreate) -> None:
+    if not KEY_PATTERN.match(data.key):
+        raise ValidationError(f"Invalid key format: {data.key}. Expected format: module.section.key")
+
+    if not data.value or not data.value.strip():
+        raise ValidationError("Translation value cannot be empty.")
+
+    result = await db.execute(
+        select(Translation).filter(
+            Translation.locale_id == data.locale_id,
+            Translation.module == data.module,
+            Translation.key == data.key
+        )
+    )
+    if result.scalars().first():
+        raise DuplicateError(f"Translation with key {data.key} for module {data.module} already exists for this locale.")


### PR DESCRIPTION
This PR implements the Phase 1 Localization / i18n module as requested in Issue #31. It introduces robust multi-language capabilities including locale management, module-scoped translation key-value stores, and formatting functions.

Key changes:
- `Locale` and `Translation` models with necessary constraints.
- Pydantic schemas for request validation and response formatting.
- Service methods for handling locale lifecycle, retrieving translations, handling fallbacks, exporting/importing JSON strings, and basic formatting.
- REST endpoints under `/api/v1/localization`.
- Validation patterns for proper locale and translation key handling.
- A local `conftest.py` inside the module tests and passing unit test suites.

---
*PR created automatically by Jules for task [7273058256482669120](https://jules.google.com/task/7273058256482669120) started by @muumuu8181*