### PR TITLE
feat(domain): Implement Phase 1 Unit of Measure module

### DIFF
--- a/src/domain/_026_unit_of_measure/README.md
+++ b/src/domain/_026_unit_of_measure/README.md
@@ -1,0 +1,17 @@
+# Unit of Measure (026)
+
+This module handles units of measure definitions and conversions between units.
+
+## Features
+- Define units of measure with configurable decimal places
+- Support unit types (count, weight, volume, length, time, area)
+- Define conversion factors between units
+- Automatic transitive conversions (e.g. M -> CM -> MM) using BFS
+
+## Endpoints
+- `POST /api/v1/uoms`: Create a UOM
+- `GET /api/v1/uoms`: List UOMs
+- `POST /api/v1/uoms/conversions`: Create a conversion factor
+- `GET /api/v1/uoms/conversions`: List conversions for a UOM
+- `POST /api/v1/uoms/convert`: Convert a quantity between units
+- `GET /api/v1/uoms/{id}/compatible`: Get all compatible units

--- a/src/domain/_026_unit_of_measure/__init__.py
+++ b/src/domain/_026_unit_of_measure/__init__.py
@@ -1,0 +1,32 @@
+"""
+Unit of Measure Module (Phase 1).
+"""
+from src.domain._026_unit_of_measure.models import UnitOfMeasure, UomConversion
+from src.domain._026_unit_of_measure.schemas import (
+    UomType, UomCreate, UomResponse, UomConversionCreate, UomConversionResponse,
+    UomConvertRequest, UomConvertResponse
+)
+from src.domain._026_unit_of_measure.service import (
+    create_uom, list_uoms, create_conversion, get_conversions,
+    convert_quantity, get_compatible_uoms
+)
+from src.domain._026_unit_of_measure.router import router
+
+__all__ = [
+    "UnitOfMeasure",
+    "UomConversion",
+    "UomType",
+    "UomCreate",
+    "UomResponse",
+    "UomConversionCreate",
+    "UomConversionResponse",
+    "UomConvertRequest",
+    "UomConvertResponse",
+    "create_uom",
+    "list_uoms",
+    "create_conversion",
+    "get_conversions",
+    "convert_quantity",
+    "get_compatible_uoms",
+    "router",
+]

--- a/src/domain/_026_unit_of_measure/models.py
+++ b/src/domain/_026_unit_of_measure/models.py
@@ -1,0 +1,37 @@
+"""
+Unit of Measure models.
+"""
+from decimal import Decimal
+from sqlalchemy import String, Integer, Boolean, Enum as SAEnum, Numeric, ForeignKey, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from shared.types import BaseModel
+from shared.schema import ColLen, Precision
+
+
+class UnitOfMeasure(BaseModel):
+    """Unit of measure definition."""
+    __tablename__ = "unit_of_measure"
+
+    code: Mapped[str] = mapped_column(String(ColLen.CODE), nullable=False, unique=True)
+    name: Mapped[str] = mapped_column(String(ColLen.NAME), nullable=False)
+    symbol: Mapped[str] = mapped_column(String(ColLen.STATUS), nullable=False)
+    uom_type: Mapped[str] = mapped_column(
+        SAEnum('count', 'weight', 'volume', 'length', 'time', 'area', name='uom_type'),
+        nullable=False
+    )
+    decimal_places: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+
+class UomConversion(BaseModel):
+    """Conversion factor between two units of measure."""
+    __tablename__ = "uom_conversion"
+    __table_args__ = (
+        UniqueConstraint('from_uom_id', 'to_uom_id', name='uq_uom_conversion_pair'),
+    )
+
+    from_uom_id: Mapped[int] = mapped_column(Integer, ForeignKey('unit_of_measure.id'), nullable=False)
+    to_uom_id: Mapped[int] = mapped_column(Integer, ForeignKey('unit_of_measure.id'), nullable=False)
+    factor: Mapped[Decimal] = mapped_column(Numeric(*Precision.RATE), nullable=False)
+    is_standard: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)

--- a/src/domain/_026_unit_of_measure/router.py
+++ b/src/domain/_026_unit_of_measure/router.py
@@ -1,0 +1,75 @@
+"""
+Unit of Measure API router.
+"""
+from typing import Optional
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.foundation._001_database.engine import get_db
+from src.domain._026_unit_of_measure.schemas import (
+    UomCreate, UomResponse, UomConversionCreate, UomConversionResponse,
+    UomConvertRequest, UomConvertResponse
+)
+from src.domain._026_unit_of_measure import service
+from shared.types import PaginatedResponse
+
+router = APIRouter(prefix="/api/v1/uoms", tags=["uoms"])
+
+
+@router.post("", response_model=UomResponse, status_code=status.HTTP_201_CREATED)
+async def create_uom(
+    data: UomCreate, db: AsyncSession = Depends(get_db)
+) -> UomResponse:
+    """Create a new unit of measure."""
+    uom = await service.create_uom(db, data)
+    return UomResponse.model_validate(uom)
+
+
+@router.get("", response_model=PaginatedResponse[UomResponse])
+async def list_uoms(
+    uom_type: Optional[str] = Query(None, description="Filter by type"),
+    is_active: Optional[bool] = Query(None, description="Filter by active status"),
+    page: int = Query(1, ge=1, description="Page number"),
+    page_size: int = Query(50, ge=1, le=500, description="Items per page"),
+    db: AsyncSession = Depends(get_db)
+) -> PaginatedResponse[UomResponse]:
+    """List units of measure."""
+    return await service.list_uoms(
+        db, uom_type=uom_type, is_active=is_active, page=page, page_size=page_size
+    )
+
+
+@router.post("/conversions", response_model=UomConversionResponse, status_code=status.HTTP_201_CREATED)
+async def create_conversion(
+    data: UomConversionCreate, db: AsyncSession = Depends(get_db)
+) -> UomConversionResponse:
+    """Create a conversion factor between two units."""
+    conversion = await service.create_conversion(db, data)
+    return UomConversionResponse.model_validate(conversion)
+
+
+@router.get("/conversions", response_model=PaginatedResponse[UomConversionResponse])
+async def list_conversions(
+    uom_id: int = Query(..., description="Unit ID to get conversions for"),
+    page: int = Query(1, ge=1, description="Page number"),
+    page_size: int = Query(50, ge=1, le=500, description="Items per page"),
+    db: AsyncSession = Depends(get_db)
+) -> PaginatedResponse[UomConversionResponse]:
+    """List conversions for a given unit."""
+    return await service.get_conversions(db, uom_id=uom_id, page=page, page_size=page_size)
+
+
+@router.post("/convert", response_model=UomConvertResponse)
+async def convert_quantity(
+    request: UomConvertRequest, db: AsyncSession = Depends(get_db)
+) -> UomConvertResponse:
+    """Convert a quantity from one unit to another."""
+    return await service.convert_quantity(db, request)
+
+
+@router.get("/{id}/compatible", response_model=list[UomResponse])
+async def get_compatible_uoms(
+    id: int, db: AsyncSession = Depends(get_db)
+) -> list[UomResponse]:
+    """Get all units that can be converted to/from the given unit."""
+    return await service.get_compatible_uoms(db, uom_id=id)

--- a/src/domain/_026_unit_of_measure/schemas.py
+++ b/src/domain/_026_unit_of_measure/schemas.py
@@ -1,0 +1,89 @@
+"""
+Unit of Measure schemas.
+"""
+from typing import Optional
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum
+from pydantic import Field
+
+from shared.types import BaseSchema, PaginatedResponse
+
+
+class UomType(str, Enum):
+    count = "count"
+    weight = "weight"
+    volume = "volume"
+    length = "length"
+    time = "time"
+    area = "area"
+
+
+from shared.schema import ColLen
+
+class UomCreate(BaseSchema):
+    """Request schema for creating a unit of measure."""
+    code: str = Field(..., min_length=1, max_length=ColLen.CODE)
+    name: str = Field(..., min_length=1, max_length=ColLen.NAME)
+    symbol: str = Field(..., min_length=1, max_length=ColLen.STATUS)
+    uom_type: UomType
+    decimal_places: int = Field(0, ge=0, le=6)
+    is_active: bool = True
+
+
+class UomResponse(BaseSchema):
+    """Response schema for a unit of measure."""
+    id: int
+    code: str
+    name: str
+    symbol: str
+    uom_type: str
+    decimal_places: int
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class UomConversionCreate(BaseSchema):
+    """Request schema for creating a UOM conversion."""
+    from_uom_id: int = Field(..., gt=0)
+    to_uom_id: int = Field(..., gt=0)
+    factor: Decimal = Field(..., gt=0)
+    is_standard: bool = False
+
+
+class UomConversionResponse(BaseSchema):
+    """Response schema for a UOM conversion."""
+    id: int
+    from_uom_id: int
+    to_uom_id: int
+    factor: Decimal
+    is_standard: bool
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class UomConvertRequest(BaseSchema):
+    """Request schema for converting between units."""
+    from_uom_id: int = Field(..., gt=0)
+    to_uom_id: int = Field(..., gt=0)
+    quantity: Decimal = Field(..., gt=0)
+
+
+class UomConvertResponse(BaseSchema):
+    """Response schema for a unit conversion result."""
+    from_uom_id: int
+    to_uom_id: int
+    input_quantity: Decimal
+    converted_quantity: Decimal
+    factor_used: Decimal
+    conversion_path: list[str]
+
+    class Config:
+        from_attributes = True

--- a/src/domain/_026_unit_of_measure/service.py
+++ b/src/domain/_026_unit_of_measure/service.py
@@ -1,0 +1,331 @@
+"""
+Unit of Measure service layer.
+"""
+import math
+from typing import Optional
+from collections import deque
+from decimal import Decimal
+
+from sqlalchemy import select, func, and_, or_
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.domain._026_unit_of_measure.models import UnitOfMeasure, UomConversion
+from src.domain._026_unit_of_measure.schemas import (
+    UomCreate, UomResponse, UomConversionCreate, UomConversionResponse,
+    UomConvertRequest, UomConvertResponse
+)
+from src.domain._026_unit_of_measure.validators import (
+    validate_code_unique, validate_factor_positive, validate_no_self_reference
+)
+from shared.types import PaginatedResponse
+from shared.errors import NotFoundError, ValidationError, DuplicateError, BusinessRuleError
+
+
+async def create_uom(db: AsyncSession, data: UomCreate) -> UnitOfMeasure:
+    """Create a new unit of measure.
+
+    Args:
+        db: Database session.
+        data: UOM creation data.
+    Returns:
+        The created UnitOfMeasure record.
+    Raises:
+        DuplicateError: If a UOM with the same code already exists.
+    """
+    code = validate_code_unique(data.code)
+
+    # Check for existing code
+    existing = await db.execute(select(UnitOfMeasure).where(UnitOfMeasure.code == code))
+    if existing.scalar_one_or_none():
+        raise DuplicateError("UnitOfMeasure", code)
+
+    uom = UnitOfMeasure(
+        code=code,
+        name=data.name,
+        symbol=data.symbol,
+        uom_type=data.uom_type.value,
+        decimal_places=data.decimal_places,
+        is_active=data.is_active
+    )
+    db.add(uom)
+    try:
+        await db.commit()
+        await db.refresh(uom)
+    except IntegrityError:
+        await db.rollback()
+        raise DuplicateError("UnitOfMeasure", code)
+
+    return uom
+
+
+async def list_uoms(
+    db: AsyncSession, uom_type: Optional[str] = None, is_active: Optional[bool] = None,
+    page: int = 1, page_size: int = 50
+) -> PaginatedResponse[UomResponse]:
+    """List units of measure with optional filtering.
+
+    Args:
+        db: Database session.
+        uom_type: Optional filter by type.
+        is_active: Optional filter by active status.
+        page: Page number.
+        page_size: Items per page.
+    Returns:
+        PaginatedResponse containing UomResponse items.
+    """
+    query = select(UnitOfMeasure)
+
+    if uom_type is not None:
+        query = query.where(UnitOfMeasure.uom_type == uom_type)
+    if is_active is not None:
+        query = query.where(UnitOfMeasure.is_active == is_active)
+
+    # Count total
+    count_query = select(func.count()).select_from(query.subquery())
+    total_result = await db.execute(count_query)
+    total = total_result.scalar_one()
+
+    # Paginate
+    query = query.order_by(UnitOfMeasure.id).offset((page - 1) * page_size).limit(page_size)
+    result = await db.execute(query)
+    items = result.scalars().all()
+
+    return PaginatedResponse(
+        items=[UomResponse.model_validate(item) for item in items],
+        total=total,
+        page=page,
+        page_size=page_size,
+        total_pages=math.ceil(total / page_size) if total > 0 else 1
+    )
+
+
+async def create_conversion(db: AsyncSession, data: UomConversionCreate) -> UomConversion:
+    """Create a conversion factor between two units.
+
+    Args:
+        db: Database session.
+        data: Conversion creation data.
+    Returns:
+        The created UomConversion record.
+    Raises:
+        ValidationError: If factor <= 0 or self-referencing.
+        NotFoundError: If from_uom_id or to_uom_id does not exist.
+        DuplicateError: If conversion already exists.
+    """
+    await validate_no_self_reference(data.from_uom_id, data.to_uom_id)
+    factor = validate_factor_positive(data.factor)
+
+    # Check if UOMs exist
+    from_uom_res = await db.execute(select(UnitOfMeasure).where(UnitOfMeasure.id == data.from_uom_id))
+    from_uom = from_uom_res.scalar_one_or_none()
+    if not from_uom:
+        raise NotFoundError("UnitOfMeasure", str(data.from_uom_id))
+
+    to_uom_res = await db.execute(select(UnitOfMeasure).where(UnitOfMeasure.id == data.to_uom_id))
+    to_uom = to_uom_res.scalar_one_or_none()
+    if not to_uom:
+        raise NotFoundError("UnitOfMeasure", str(data.to_uom_id))
+
+    # Check for existing conversion
+    existing = await db.execute(
+        select(UomConversion).where(
+            UomConversion.from_uom_id == data.from_uom_id,
+            UomConversion.to_uom_id == data.to_uom_id
+        )
+    )
+    if existing.scalar_one_or_none():
+        raise DuplicateError("UomConversion")
+
+    conversion = UomConversion(
+        from_uom_id=data.from_uom_id,
+        to_uom_id=data.to_uom_id,
+        factor=factor,
+        is_standard=data.is_standard
+    )
+    db.add(conversion)
+    try:
+        await db.commit()
+        await db.refresh(conversion)
+    except IntegrityError:
+        await db.rollback()
+        raise DuplicateError("UomConversion")
+
+    return conversion
+
+
+async def get_conversions(
+    db: AsyncSession, uom_id: int, page: int = 1, page_size: int = 50
+) -> PaginatedResponse[UomConversionResponse]:
+    """Get all conversions for a given unit.
+
+    Args:
+        db: Database session.
+        uom_id: Unit ID to get conversions for.
+        page: Page number.
+        page_size: Items per page.
+    Returns:
+        PaginatedResponse of UomConversionResponse items.
+    """
+    query = select(UomConversion).where(
+        or_(
+            UomConversion.from_uom_id == uom_id,
+            UomConversion.to_uom_id == uom_id
+        )
+    )
+
+    # Count total
+    count_query = select(func.count()).select_from(query.subquery())
+    total_result = await db.execute(count_query)
+    total = total_result.scalar_one()
+
+    # Paginate
+    query = query.order_by(UomConversion.id).offset((page - 1) * page_size).limit(page_size)
+    result = await db.execute(query)
+    items = result.scalars().all()
+
+    return PaginatedResponse(
+        items=[UomConversionResponse.model_validate(item) for item in items],
+        total=total,
+        page=page,
+        page_size=page_size,
+        total_pages=math.ceil(total / page_size) if total > 0 else 1
+    )
+
+
+async def _get_all_conversions_graph(db: AsyncSession) -> dict[int, list[tuple[int, Decimal]]]:
+    """Helper to build a graph of all conversions."""
+    query = select(UomConversion)
+    result = await db.execute(query)
+    conversions = result.scalars().all()
+
+    graph: dict[int, list[tuple[int, Decimal]]] = {}
+    for conv in conversions:
+        if conv.from_uom_id not in graph:
+            graph[conv.from_uom_id] = []
+        if conv.to_uom_id not in graph:
+            graph[conv.to_uom_id] = []
+
+        # Add forward edge
+        graph[conv.from_uom_id].append((conv.to_uom_id, Decimal(str(conv.factor))))
+        # Add backward edge
+        graph[conv.to_uom_id].append((conv.from_uom_id, Decimal('1') / Decimal(str(conv.factor))))
+
+    return graph
+
+async def _get_uom_codes(db: AsyncSession, ids: list[int]) -> dict[int, str]:
+    query = select(UnitOfMeasure).where(UnitOfMeasure.id.in_(ids))
+    result = await db.execute(query)
+    uoms = result.scalars().all()
+    return {uom.id: uom.code for uom in uoms}
+
+async def convert_quantity(db: AsyncSession, request: UomConvertRequest) -> UomConvertResponse:
+    """Convert a quantity from one unit to another.
+
+    Supports transitive conversions: if direct A->B is not defined but
+    A->C and C->B exist, the conversion is computed via the intermediate.
+    Uses BFS/DFS to find the shortest conversion path.
+
+    Args:
+        db: Database session.
+        request: Conversion request with from, to, and quantity.
+    Returns:
+        UomConvertResponse with converted value and conversion path.
+    Raises:
+        NotFoundError: If units do not exist.
+        BusinessRuleError: If no conversion path exists.
+    """
+    if request.from_uom_id == request.to_uom_id:
+        path = await _get_uom_codes(db, [request.from_uom_id])
+        return UomConvertResponse(
+            from_uom_id=request.from_uom_id,
+            to_uom_id=request.to_uom_id,
+            input_quantity=request.quantity,
+            converted_quantity=request.quantity,
+            factor_used=Decimal('1'),
+            conversion_path=[path.get(request.from_uom_id, str(request.from_uom_id))]
+        )
+
+    # Validate existance of both units
+    from_uom_res = await db.execute(select(UnitOfMeasure).where(UnitOfMeasure.id == request.from_uom_id))
+    if not from_uom_res.scalar_one_or_none():
+        raise NotFoundError("UnitOfMeasure", str(request.from_uom_id))
+
+    to_uom_res = await db.execute(select(UnitOfMeasure).where(UnitOfMeasure.id == request.to_uom_id))
+    if not to_uom_res.scalar_one_or_none():
+        raise NotFoundError("UnitOfMeasure", str(request.to_uom_id))
+
+    graph = await _get_all_conversions_graph(db)
+
+    if request.from_uom_id not in graph:
+        raise BusinessRuleError("No conversion path exists.")
+
+    # BFS
+    queue: deque[tuple[int, Decimal, list[int]]] = deque([(request.from_uom_id, Decimal('1'), [request.from_uom_id])])
+    visited = {request.from_uom_id}
+
+    while queue:
+        current_node, current_factor, path = queue.popleft()
+
+        if current_node == request.to_uom_id:
+            # We found a path
+            uom_codes = await _get_uom_codes(db, path)
+            code_path = [uom_codes.get(p, str(p)) for p in path]
+            return UomConvertResponse(
+                from_uom_id=request.from_uom_id,
+                to_uom_id=request.to_uom_id,
+                input_quantity=request.quantity,
+                converted_quantity=request.quantity * current_factor,
+                factor_used=current_factor,
+                conversion_path=code_path
+            )
+
+        for neighbor, factor in graph.get(current_node, []):
+            if neighbor not in visited:
+                visited.add(neighbor)
+                queue.append((neighbor, current_factor * factor, path + [neighbor]))
+
+    raise BusinessRuleError("No conversion path exists.")
+
+
+async def get_compatible_uoms(db: AsyncSession, uom_id: int) -> list[UomResponse]:
+    """Get all units that can be converted to/from the given unit.
+
+    Uses graph traversal to find all reachable units through conversion chains.
+
+    Args:
+        db: Database session.
+        uom_id: Unit ID to find compatible units for.
+    Returns:
+        List of compatible UomResponse items.
+    Raises:
+        NotFoundError: If the unit does not exist.
+    """
+    uom_res = await db.execute(select(UnitOfMeasure).where(UnitOfMeasure.id == uom_id))
+    if not uom_res.scalar_one_or_none():
+        raise NotFoundError("UnitOfMeasure", str(uom_id))
+
+    graph = await _get_all_conversions_graph(db)
+
+    reachable_ids = set()
+    if uom_id in graph:
+        # BFS
+        queue = deque([uom_id])
+        visited = {uom_id}
+
+        while queue:
+            current = queue.popleft()
+            for neighbor, _ in graph.get(current, []):
+                if neighbor not in visited:
+                    visited.add(neighbor)
+                    reachable_ids.add(neighbor)
+                    queue.append(neighbor)
+
+    # Even if no conversions, unit is compatible with itself
+    reachable_ids.add(uom_id)
+
+    query = select(UnitOfMeasure).where(UnitOfMeasure.id.in_(reachable_ids))
+    result = await db.execute(query)
+    uoms = result.scalars().all()
+
+    return [UomResponse.model_validate(uom) for uom in uoms]

--- a/src/domain/_026_unit_of_measure/tests/conftest.py
+++ b/src/domain/_026_unit_of_measure/tests/conftest.py
@@ -1,0 +1,69 @@
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from httpx import AsyncClient, ASGITransport
+
+from shared.types import Base
+from shared.errors import DuplicateError, NotFoundError, BusinessRuleError, ValidationError
+
+# Setup an in-memory SQLite database for testing
+TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+
+engine = create_async_engine(TEST_DATABASE_URL, echo=False)
+TestingSessionLocal = async_sessionmaker(
+    bind=engine, class_=AsyncSession, expire_on_commit=False
+)
+
+@pytest_asyncio.fixture(scope="function")
+async def db_session():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with TestingSessionLocal() as session:
+        yield session
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+@pytest_asyncio.fixture(scope="function")
+async def async_client(db_session):
+    from src.domain._026_unit_of_measure.router import router
+    from src.foundation._001_database.engine import get_db
+
+    app = FastAPI()
+    app.include_router(router)
+
+    # Add exception handlers expected by the module
+    @app.exception_handler(DuplicateError)
+    async def duplicate_error_handler(request: Request, exc: DuplicateError):
+        return JSONResponse(
+            status_code=409,
+            content={"message": str(exc)},
+        )
+
+    @app.exception_handler(ValidationError)
+    async def validation_error_handler(request: Request, exc: ValidationError):
+        return JSONResponse(
+            status_code=422,
+            content={"message": str(exc)},
+        )
+
+    @app.exception_handler(NotFoundError)
+    async def not_found_error_handler(request: Request, exc: NotFoundError):
+        return JSONResponse(
+            status_code=404,
+            content={"message": str(exc)},
+        )
+
+    # Override dependency to use the test db session
+    async def override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        yield client

--- a/src/domain/_026_unit_of_measure/tests/test_models.py
+++ b/src/domain/_026_unit_of_measure/tests/test_models.py
@@ -1,0 +1,96 @@
+"""
+Tests for Unit of Measure models.
+"""
+from decimal import Decimal
+import pytest
+from sqlalchemy.exc import IntegrityError
+from src.domain._026_unit_of_measure.models import UnitOfMeasure, UomConversion
+from src.domain._026_unit_of_measure.schemas import UomType
+
+
+@pytest.mark.asyncio
+async def test_uom_instantiation(db_session):
+    uom = UnitOfMeasure(
+        code="TEST",
+        name="Test Unit",
+        symbol="tst",
+        uom_type=UomType.count.value
+    )
+    db_session.add(uom)
+    await db_session.commit()
+    await db_session.refresh(uom)
+
+    assert uom.id is not None
+    assert uom.code == "TEST"
+    assert uom.decimal_places == 0
+    assert uom.is_active is True
+    assert uom.created_at is not None
+    assert uom.updated_at is not None
+
+
+@pytest.mark.asyncio
+async def test_uom_code_unique(db_session):
+    uom1 = UnitOfMeasure(
+        code="DUP",
+        name="Unit 1",
+        symbol="u1",
+        uom_type=UomType.count.value
+    )
+    db_session.add(uom1)
+    await db_session.commit()
+
+    uom2 = UnitOfMeasure(
+        code="DUP",
+        name="Unit 2",
+        symbol="u2",
+        uom_type=UomType.weight.value
+    )
+    db_session.add(uom2)
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_uom_conversion_instantiation(db_session):
+    uom1 = UnitOfMeasure(code="U1", name="Unit 1", symbol="u1", uom_type="count")
+    uom2 = UnitOfMeasure(code="U2", name="Unit 2", symbol="u2", uom_type="count")
+    db_session.add_all([uom1, uom2])
+    await db_session.commit()
+    await db_session.refresh(uom1)
+    await db_session.refresh(uom2)
+
+    conv = UomConversion(
+        from_uom_id=uom1.id,
+        to_uom_id=uom2.id,
+        factor=Decimal("10.5")
+    )
+    db_session.add(conv)
+    await db_session.commit()
+    await db_session.refresh(conv)
+
+    assert conv.id is not None
+    assert conv.from_uom_id == uom1.id
+    assert conv.to_uom_id == uom2.id
+    assert conv.factor == Decimal("10.5")
+    assert conv.is_standard is False
+
+
+@pytest.mark.asyncio
+async def test_uom_conversion_unique_pair(db_session):
+    uom1 = UnitOfMeasure(code="U3", name="Unit 3", symbol="u3", uom_type="count")
+    uom2 = UnitOfMeasure(code="U4", name="Unit 4", symbol="u4", uom_type="count")
+    db_session.add_all([uom1, uom2])
+    await db_session.commit()
+
+    conv1 = UomConversion(from_uom_id=uom1.id, to_uom_id=uom2.id, factor=Decimal("2"))
+    db_session.add(conv1)
+    await db_session.commit()
+
+    conv2 = UomConversion(from_uom_id=uom1.id, to_uom_id=uom2.id, factor=Decimal("3"))
+    db_session.add(conv2)
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+    await db_session.rollback()

--- a/src/domain/_026_unit_of_measure/tests/test_router.py
+++ b/src/domain/_026_unit_of_measure/tests/test_router.py
@@ -1,0 +1,100 @@
+"""
+Tests for Unit of Measure router.
+"""
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+
+@pytest.mark.asyncio
+async def test_create_uom(async_client):
+    response = await async_client.post("/api/v1/uoms", json={
+        "code": "TEST_UOM",
+        "name": "Test UOM",
+        "symbol": "tu",
+        "uom_type": "count",
+        "decimal_places": 0
+    })
+    assert response.status_code == 201
+    data = response.json()
+    assert data["code"] == "TEST_UOM"
+
+    # Duplicate code
+    response2 = await async_client.post("/api/v1/uoms", json={
+        "code": "TEST_UOM",
+        "name": "Another UOM",
+        "symbol": "au",
+        "uom_type": "count",
+        "decimal_places": 0
+    })
+    # Error handling middleware usually converts to 409
+    # But since we're assuming the shared.errors handlers are in place, we just expect not 201
+    assert response2.status_code in (400, 409)
+
+
+@pytest.mark.asyncio
+async def test_list_uoms(async_client):
+    # Setup some data
+    await async_client.post("/api/v1/uoms", json={
+        "code": "UOM1", "name": "U 1", "symbol": "u1", "uom_type": "count", "decimal_places": 0
+    })
+    await async_client.post("/api/v1/uoms", json={
+        "code": "UOM2", "name": "U 2", "symbol": "u2", "uom_type": "weight", "decimal_places": 0
+    })
+
+    response = await async_client.get("/api/v1/uoms")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] >= 2
+
+    # Filter
+    response = await async_client.get("/api/v1/uoms?uom_type=weight")
+    assert response.status_code == 200
+    data = response.json()
+    assert all(item["uom_type"] == "weight" for item in data["items"])
+
+
+@pytest.mark.asyncio
+async def test_conversions(async_client):
+    res1 = await async_client.post("/api/v1/uoms", json={
+        "code": "U1", "name": "U 1", "symbol": "u1", "uom_type": "count", "decimal_places": 0
+    })
+    res2 = await async_client.post("/api/v1/uoms", json={
+        "code": "U2", "name": "U 2", "symbol": "u2", "uom_type": "count", "decimal_places": 0
+    })
+    id1 = res1.json()["id"]
+    id2 = res2.json()["id"]
+
+    # Create conversion
+    conv_res = await async_client.post("/api/v1/uoms/conversions", json={
+        "from_uom_id": id1,
+        "to_uom_id": id2,
+        "factor": 10.5
+    })
+    assert conv_res.status_code == 201
+
+    # Self reference
+    conv_err = await async_client.post("/api/v1/uoms/conversions", json={
+        "from_uom_id": id1,
+        "to_uom_id": id1,
+        "factor": 10.5
+    })
+    assert conv_err.status_code in (400, 422)
+
+    # List conversions
+    list_res = await async_client.get(f"/api/v1/uoms/conversions?uom_id={id1}")
+    assert list_res.status_code == 200
+    assert list_res.json()["total"] == 1
+
+    # Convert quantity
+    convert_res = await async_client.post("/api/v1/uoms/convert", json={
+        "from_uom_id": id1,
+        "to_uom_id": id2,
+        "quantity": 2
+    })
+    assert convert_res.status_code == 200
+    assert float(convert_res.json()["converted_quantity"]) == 21.0
+
+    # Get compatible
+    compat_res = await async_client.get(f"/api/v1/uoms/{id1}/compatible")
+    assert compat_res.status_code == 200
+    assert len(compat_res.json()) >= 2

--- a/src/domain/_026_unit_of_measure/tests/test_service.py
+++ b/src/domain/_026_unit_of_measure/tests/test_service.py
@@ -1,0 +1,155 @@
+"""
+Tests for Unit of Measure service.
+"""
+import pytest
+from decimal import Decimal
+from src.domain._026_unit_of_measure import service
+from src.domain._026_unit_of_measure.schemas import (
+    UomCreate, UomType, UomConversionCreate, UomConvertRequest
+)
+from shared.errors import DuplicateError, NotFoundError, BusinessRuleError, ValidationError
+
+
+@pytest.fixture
+async def uom_data(db_session):
+    uom1 = await service.create_uom(db_session, UomCreate(
+        code="M", name="Meter", symbol="m", uom_type=UomType.length, decimal_places=2
+    ))
+    uom2 = await service.create_uom(db_session, UomCreate(
+        code="CM", name="Centimeter", symbol="cm", uom_type=UomType.length, decimal_places=0
+    ))
+    uom3 = await service.create_uom(db_session, UomCreate(
+        code="MM", name="Millimeter", symbol="mm", uom_type=UomType.length, decimal_places=0
+    ))
+    uom_kg = await service.create_uom(db_session, UomCreate(
+        code="KG", name="Kilogram", symbol="kg", uom_type=UomType.weight, decimal_places=2
+    ))
+
+    await service.create_conversion(db_session, UomConversionCreate(
+        from_uom_id=uom1.id, to_uom_id=uom2.id, factor=Decimal("100")
+    ))
+    await service.create_conversion(db_session, UomConversionCreate(
+        from_uom_id=uom2.id, to_uom_id=uom3.id, factor=Decimal("10")
+    ))
+
+    return {"M": uom1, "CM": uom2, "MM": uom3, "KG": uom_kg}
+
+
+@pytest.mark.asyncio
+async def test_create_uom(db_session):
+    uom = await service.create_uom(db_session, UomCreate(
+        code="PCS", name="Pieces", symbol="pcs", uom_type=UomType.count
+    ))
+    assert uom.code == "PCS"
+    assert uom.uom_type == "count"
+
+    with pytest.raises(DuplicateError):
+        await service.create_uom(db_session, UomCreate(
+            code="PCS", name="Pieces Dup", symbol="pcs", uom_type=UomType.count
+        ))
+
+
+@pytest.mark.asyncio
+async def test_list_uoms(db_session, uom_data):
+    # Get all
+    result = await service.list_uoms(db_session)
+    assert result.total >= 4
+
+    # Filter by type
+    result = await service.list_uoms(db_session, uom_type=UomType.length.value)
+    assert result.total == 3
+    assert all(u.uom_type == 'length' for u in result.items)
+
+    # Filter by active
+    result = await service.list_uoms(db_session, is_active=True)
+    assert result.total >= 4
+
+
+@pytest.mark.asyncio
+async def test_create_conversion(db_session, uom_data):
+    m = uom_data["M"]
+    kg = uom_data["KG"]
+
+    conv = await service.create_conversion(db_session, UomConversionCreate(
+        from_uom_id=m.id, to_uom_id=kg.id, factor=Decimal("1") # silly conversion but for testing
+    ))
+    assert conv.factor == Decimal("1")
+
+    with pytest.raises(DuplicateError):
+        await service.create_conversion(db_session, UomConversionCreate(
+            from_uom_id=m.id, to_uom_id=kg.id, factor=Decimal("2")
+        ))
+
+    with pytest.raises(ValidationError):
+        await service.create_conversion(db_session, UomConversionCreate(
+            from_uom_id=m.id, to_uom_id=m.id, factor=Decimal("1")
+        ))
+
+    # Validation error for negative factor is caught by Pydantic schema
+    try:
+        UomConversionCreate(
+            from_uom_id=m.id, to_uom_id=kg.id, factor=Decimal("-1")
+        )
+        assert False, "Should raise ValidationError"
+    except Exception as e:
+        assert True
+
+
+@pytest.mark.asyncio
+async def test_convert_quantity(db_session, uom_data):
+    m = uom_data["M"]
+    cm = uom_data["CM"]
+    mm = uom_data["MM"]
+    kg = uom_data["KG"]
+
+    # Direct conversion
+    res1 = await service.convert_quantity(db_session, UomConvertRequest(
+        from_uom_id=m.id, to_uom_id=cm.id, quantity=Decimal("2")
+    ))
+    assert res1.converted_quantity == Decimal("200")
+    assert res1.factor_used == Decimal("100")
+
+    # Reverse conversion
+    res2 = await service.convert_quantity(db_session, UomConvertRequest(
+        from_uom_id=cm.id, to_uom_id=m.id, quantity=Decimal("200")
+    ))
+    assert res2.converted_quantity == Decimal("2")
+    assert res2.factor_used == Decimal("0.01")
+
+    # Transitive conversion
+    res3 = await service.convert_quantity(db_session, UomConvertRequest(
+        from_uom_id=m.id, to_uom_id=mm.id, quantity=Decimal("2")
+    ))
+    assert res3.converted_quantity == Decimal("2000")
+    assert res3.factor_used == Decimal("1000")
+
+    # No path
+    with pytest.raises(BusinessRuleError):
+        await service.convert_quantity(db_session, UomConvertRequest(
+            from_uom_id=m.id, to_uom_id=kg.id, quantity=Decimal("1")
+        ))
+
+
+@pytest.mark.asyncio
+async def test_get_conversions(db_session, uom_data):
+    m = uom_data["M"]
+    result = await service.get_conversions(db_session, m.id)
+    assert result.total == 1
+    assert result.items[0].from_uom_id == m.id
+
+
+@pytest.mark.asyncio
+async def test_get_compatible_uoms(db_session, uom_data):
+    m = uom_data["M"]
+    kg = uom_data["KG"]
+
+    compat = await service.get_compatible_uoms(db_session, m.id)
+    assert len(compat) == 3 # M, CM, MM
+    ids = [u.id for u in compat]
+    assert m.id in ids
+    assert uom_data["CM"].id in ids
+    assert uom_data["MM"].id in ids
+    assert kg.id not in ids
+
+    compat_kg = await service.get_compatible_uoms(db_session, kg.id)
+    assert len(compat_kg) == 1 # Only KG itself

--- a/src/domain/_026_unit_of_measure/tests/test_validators.py
+++ b/src/domain/_026_unit_of_measure/tests/test_validators.py
@@ -1,0 +1,42 @@
+"""
+Tests for Unit of Measure validators.
+"""
+import pytest
+from decimal import Decimal
+from shared.errors import ValidationError
+from src.domain._026_unit_of_measure.validators import (
+    validate_code_unique,
+    validate_factor_positive,
+    validate_no_self_reference
+)
+
+
+def test_validate_code_unique():
+    assert validate_code_unique("kg") == "KG"
+    assert validate_code_unique(" PCS ") == "PCS"
+
+    with pytest.raises(ValidationError):
+        validate_code_unique("")
+
+    with pytest.raises(ValidationError):
+        validate_code_unique("   ")
+
+
+def test_validate_factor_positive():
+    assert validate_factor_positive(Decimal("1000.0")) == Decimal("1000.0")
+    assert validate_factor_positive(Decimal("0.001")) == Decimal("0.001")
+
+    with pytest.raises(ValidationError):
+        validate_factor_positive(Decimal("0"))
+
+    with pytest.raises(ValidationError):
+        validate_factor_positive(Decimal("-1"))
+
+
+@pytest.mark.asyncio
+async def test_validate_no_self_reference():
+    # different ids - ok
+    await validate_no_self_reference(1, 2)
+
+    with pytest.raises(ValidationError):
+        await validate_no_self_reference(1, 1)

--- a/src/domain/_026_unit_of_measure/validators.py
+++ b/src/domain/_026_unit_of_measure/validators.py
@@ -1,0 +1,48 @@
+"""
+Unit of Measure validators.
+"""
+from decimal import Decimal
+from shared.errors import ValidationError
+
+
+def validate_code_unique(value: str) -> str:
+    """Validate UOM code format and uniqueness.
+
+    Args:
+        value: The UOM code string.
+    Returns:
+        The validated code (uppercased).
+    Raises:
+        ValidationError: If code format is invalid.
+    """
+    if not value or not value.strip():
+        raise ValidationError("Code cannot be empty.", field="code")
+    return value.strip().upper()
+
+
+def validate_factor_positive(value: Decimal) -> Decimal:
+    """Validate that the conversion factor is positive.
+
+    Args:
+        value: The conversion factor.
+    Returns:
+        The validated factor.
+    Raises:
+        ValidationError: If factor <= 0.
+    """
+    if value <= Decimal('0'):
+        raise ValidationError("Factor must be greater than zero.", field="factor")
+    return value
+
+
+async def validate_no_self_reference(from_uom_id: int, to_uom_id: int) -> None:
+    """Validate that from and to UOM are not the same.
+
+    Args:
+        from_uom_id: Source unit ID.
+        to_uom_id: Target unit ID.
+    Raises:
+        ValidationError: If from_uom_id == to_uom_id.
+    """
+    if from_uom_id == to_uom_id:
+        raise ValidationError("Cannot convert a unit to itself.")


### PR DESCRIPTION
This PR implements the Phase 1 Unit of Measure module (Issue #36).
It adds the `src/domain/_026_unit_of_measure/` directory with:
- `models.py` and `schemas.py` using `shared.schema.ColLen` and `shared.types`
- `validators.py` for conversion logic safety
- `service.py` featuring a BFS-based transitive conversion algorithm
- API `router.py` with CRUD and conversion endpoints
- Fully passing async test suite

---
*PR created automatically by Jules for task [11167552693864807704](https://jules.google.com/task/11167552693864807704) started by @muumuu8181*