### PR TITLE
feat: implement Warehouse Master Data module (#37)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 *.sqlite3
 .pytest_cache/
 .mypy_cache/
+.venv

--- a/src/domain/_027_warehouse_model/README.md
+++ b/src/domain/_027_warehouse_model/README.md
@@ -1,0 +1,11 @@
+# Warehouse Master Data
+
+Warehouse management module for handling `Warehouse`, `WarehouseZone`, and `BinLocation` models.
+
+## Usage
+Provides REST APIs for:
+- Creating/Updating warehouses.
+- Creating zones inside warehouses.
+- Creating bin locations inside zones.
+- Retrieving paginated list of warehouses, zones, and bins.
+- Fetching full layout tree.

--- a/src/domain/_027_warehouse_model/__init__.py
+++ b/src/domain/_027_warehouse_model/__init__.py
@@ -1,0 +1,20 @@
+"""Warehouse Model module for ERP Ultra.
+
+Manages warehouses, zones, and bin locations.
+"""
+
+from src.domain._027_warehouse_model.models import Warehouse, WarehouseZone, BinLocation
+from src.domain._027_warehouse_model.schemas import WarehouseCreate, WarehouseResponse
+from src.domain._027_warehouse_model.service import create_warehouse, get_warehouse_layout
+from src.domain._027_warehouse_model.router import router
+
+__all__ = [
+    "Warehouse",
+    "WarehouseZone",
+    "BinLocation",
+    "WarehouseCreate",
+    "WarehouseResponse",
+    "create_warehouse",
+    "get_warehouse_layout",
+    "router",
+]

--- a/src/domain/_027_warehouse_model/models.py
+++ b/src/domain/_027_warehouse_model/models.py
@@ -1,0 +1,61 @@
+from sqlalchemy import String, Boolean, Enum as SAEnum, Integer, ForeignKey, UniqueConstraint, Numeric
+from sqlalchemy.orm import Mapped, mapped_column
+from shared.types import BaseModel
+from typing import Optional
+from decimal import Decimal
+from src.domain._027_warehouse_model.schemas import WarehouseType, ZoneType, TemperatureZone
+
+class Warehouse(BaseModel):
+    """Warehouse master data."""
+    __tablename__ = "warehouse"
+
+    code: Mapped[str] = mapped_column(String(50), nullable=False, unique=True)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    type: Mapped[WarehouseType] = mapped_column(
+        SAEnum(WarehouseType, name='warehouse_type'),
+        nullable=False
+    )
+    postal_code: Mapped[Optional[str]] = mapped_column(String(8), nullable=True)
+    prefecture: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+    city: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    street: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)
+    manager_name: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    phone: Mapped[Optional[str]] = mapped_column(String(20), nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+class WarehouseZone(BaseModel):
+    """Zone within a warehouse."""
+    __tablename__ = "warehouse_zone"
+    __table_args__ = (
+        UniqueConstraint('warehouse_id', 'code', name='uq_zone_warehouse_code'),
+    )
+
+    warehouse_id: Mapped[int] = mapped_column(Integer, ForeignKey('warehouse.id'), nullable=False)
+    code: Mapped[str] = mapped_column(String(50), nullable=False)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    zone_type: Mapped[ZoneType] = mapped_column(
+        SAEnum(ZoneType, name='zone_type'),
+        nullable=False
+    )
+    temperature_zone: Mapped[TemperatureZone] = mapped_column(
+        SAEnum(TemperatureZone, name='temperature_zone'),
+        nullable=False, default=TemperatureZone.ambient
+    )
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+class BinLocation(BaseModel):
+    """Bin location within a warehouse zone."""
+    __tablename__ = "bin_location"
+    __table_args__ = (
+        UniqueConstraint('zone_id', 'code', name='uq_bin_zone_code'),
+    )
+
+    zone_id: Mapped[int] = mapped_column(Integer, ForeignKey('warehouse_zone.id'), nullable=False)
+    code: Mapped[str] = mapped_column(String(50), nullable=False)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    row: Mapped[Optional[str]] = mapped_column(String(10), nullable=True)
+    column: Mapped[Optional[str]] = mapped_column(String(10), nullable=True)
+    level: Mapped[Optional[str]] = mapped_column(String(10), nullable=True)
+    capacity: Mapped[Optional[Decimal]] = mapped_column(Numeric(15, 3), nullable=True)
+    current_usage: Mapped[Optional[Decimal]] = mapped_column(Numeric(15, 3), nullable=True, default=0)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)

--- a/src/domain/_027_warehouse_model/router.py
+++ b/src/domain/_027_warehouse_model/router.py
@@ -1,0 +1,108 @@
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+from typing import Optional
+
+from src.foundation._001_database.engine import get_db
+from shared.types import PaginatedResponse
+from src.domain._027_warehouse_model import service
+from src.domain._027_warehouse_model.schemas import (
+    WarehouseCreate, WarehouseUpdate, ZoneCreate, BinCreate, WarehouseLayoutResponse,
+    WarehouseResponse, ZoneResponse, BinResponse
+)
+
+router = APIRouter(prefix="/api/v1", tags=["warehouses"])
+
+
+@router.post("/warehouses", response_model=WarehouseResponse, status_code=201)
+async def create_warehouse(
+    data: WarehouseCreate,
+    db: AsyncSession = Depends(get_db)
+) -> WarehouseResponse:
+    """Create a new warehouse."""
+    warehouse = await service.create_warehouse(db, data)
+    return WarehouseResponse.model_validate(warehouse)
+
+
+@router.get("/warehouses", response_model=PaginatedResponse[WarehouseResponse])
+async def list_warehouses(
+    is_active: Optional[bool] = Query(None),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    db: AsyncSession = Depends(get_db)
+) -> PaginatedResponse[WarehouseResponse]:
+    """List warehouses."""
+    return await service.list_warehouses(db, is_active=is_active, page=page, page_size=page_size)
+
+
+@router.get("/warehouses/{warehouse_id}", response_model=WarehouseResponse)
+async def get_warehouse(
+    warehouse_id: int,
+    db: AsyncSession = Depends(get_db)
+) -> WarehouseResponse:
+    """Get warehouse by ID."""
+    warehouse = await service.get_warehouse(db, warehouse_id)
+    return WarehouseResponse.model_validate(warehouse)
+
+
+@router.put("/warehouses/{warehouse_id}", response_model=WarehouseResponse)
+async def update_warehouse(
+    warehouse_id: int,
+    data: WarehouseUpdate,
+    db: AsyncSession = Depends(get_db)
+) -> WarehouseResponse:
+    """Update warehouse."""
+    warehouse = await service.update_warehouse(db, warehouse_id, data)
+    return WarehouseResponse.model_validate(warehouse)
+
+
+@router.post("/warehouses/{warehouse_id}/zones", response_model=ZoneResponse, status_code=201)
+async def create_zone(
+    warehouse_id: int,
+    data: ZoneCreate,
+    db: AsyncSession = Depends(get_db)
+) -> ZoneResponse:
+    """Create a new zone in a warehouse."""
+    zone = await service.create_zone(db, warehouse_id, data)
+    return ZoneResponse.model_validate(zone)
+
+
+@router.get("/warehouses/{warehouse_id}/zones", response_model=PaginatedResponse[ZoneResponse])
+async def list_zones(
+    warehouse_id: int,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    db: AsyncSession = Depends(get_db)
+) -> PaginatedResponse[ZoneResponse]:
+    """List zones in a warehouse."""
+    return await service.list_zones(db, warehouse_id, page=page, page_size=page_size)
+
+
+@router.post("/zones/{zone_id}/bins", response_model=BinResponse, status_code=201)
+async def create_bin(
+    zone_id: int,
+    data: BinCreate,
+    db: AsyncSession = Depends(get_db)
+) -> BinResponse:
+    """Create a new bin in a zone."""
+    bin_loc = await service.create_bin(db, zone_id, data)
+    return BinResponse.model_validate(bin_loc)
+
+
+@router.get("/zones/{zone_id}/bins", response_model=PaginatedResponse[BinResponse])
+async def list_bins(
+    zone_id: int,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    db: AsyncSession = Depends(get_db)
+) -> PaginatedResponse[BinResponse]:
+    """List bins in a zone."""
+    return await service.list_bins(db, zone_id, page=page, page_size=page_size)
+
+
+@router.get("/warehouses/{warehouse_id}/layout", response_model=WarehouseLayoutResponse)
+async def get_warehouse_layout(
+    warehouse_id: int,
+    db: AsyncSession = Depends(get_db)
+) -> WarehouseLayoutResponse:
+    """Get the full warehouse layout."""
+    return await service.get_warehouse_layout(db, warehouse_id)

--- a/src/domain/_027_warehouse_model/schemas.py
+++ b/src/domain/_027_warehouse_model/schemas.py
@@ -1,0 +1,129 @@
+from shared.types import BaseSchema, PaginatedResponse
+from shared.schema import ColLen
+from pydantic import Field
+from typing import Optional, Any
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum
+
+class WarehouseType(str, Enum):
+    own = "own"
+    consignment = "consignment"
+    virtual = "virtual"
+
+class ZoneType(str, Enum):
+    receiving = "receiving"
+    storage = "storage"
+    picking = "picking"
+    shipping = "shipping"
+    staging = "staging"
+
+class TemperatureZone(str, Enum):
+    ambient = "ambient"
+    refrigerated = "refrigerated"
+    frozen = "frozen"
+
+class WarehouseCreate(BaseSchema):
+    """Request schema for creating a warehouse."""
+    code: str = Field(..., min_length=1, max_length=50)
+    name: str = Field(..., min_length=1, max_length=200)
+    type: WarehouseType
+    postal_code: Optional[str] = Field(None, max_length=8)
+    prefecture: Optional[str] = Field(None, max_length=50)
+    city: Optional[str] = Field(None, max_length=100)
+    street: Optional[str] = Field(None, max_length=200)
+    manager_name: Optional[str] = Field(None, max_length=100)
+    phone: Optional[str] = Field(None, max_length=ColLen.PHONE)
+    is_active: bool = True
+
+class WarehouseUpdate(BaseSchema):
+    """Request schema for updating a warehouse."""
+    name: Optional[str] = Field(None, min_length=1, max_length=200)
+    type: Optional[WarehouseType] = None
+    postal_code: Optional[str] = Field(None, max_length=8)
+    prefecture: Optional[str] = Field(None, max_length=50)
+    city: Optional[str] = Field(None, max_length=100)
+    street: Optional[str] = Field(None, max_length=200)
+    manager_name: Optional[str] = Field(None, max_length=100)
+    phone: Optional[str] = Field(None, max_length=ColLen.PHONE)
+    is_active: Optional[bool] = None
+
+class WarehouseResponse(BaseSchema):
+    """Response schema for a warehouse."""
+    id: int
+    code: str
+    name: str
+    type: str
+    postal_code: Optional[str]
+    prefecture: Optional[str]
+    city: Optional[str]
+    street: Optional[str]
+    manager_name: Optional[str]
+    phone: Optional[str]
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+class ZoneCreate(BaseSchema):
+    """Request schema for creating a warehouse zone."""
+    code: str = Field(..., min_length=1, max_length=50)
+    name: str = Field(..., min_length=1, max_length=100)
+    zone_type: ZoneType
+    temperature_zone: TemperatureZone = TemperatureZone.ambient
+    is_active: bool = True
+
+class ZoneResponse(BaseSchema):
+    """Response schema for a warehouse zone."""
+    id: int
+    warehouse_id: int
+    code: str
+    name: str
+    zone_type: str
+    temperature_zone: str
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+class BinCreate(BaseSchema):
+    """Request schema for creating a bin location."""
+    code: str = Field(..., min_length=1, max_length=50)
+    name: str = Field(..., min_length=1, max_length=100)
+    row: Optional[str] = Field(None, max_length=10)
+    column: Optional[str] = Field(None, max_length=10)
+    level: Optional[str] = Field(None, max_length=10)
+    capacity: Optional[Decimal] = Field(None, gt=0)
+    current_usage: Optional[Decimal] = Field(0, ge=0)
+    is_active: bool = True
+
+class BinResponse(BaseSchema):
+    """Response schema for a bin location."""
+    id: int
+    zone_id: int
+    code: str
+    name: str
+    row: Optional[str]
+    column: Optional[str]
+    level: Optional[str]
+    capacity: Optional[Decimal]
+    current_usage: Optional[Decimal]
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+class ZoneLayoutResponse(ZoneResponse):
+    """Response schema for a zone including nested bins."""
+    bins: list[BinResponse]
+
+class WarehouseLayoutResponse(BaseSchema):
+    """Response schema for full warehouse layout."""
+    warehouse: WarehouseResponse
+    zones: list[ZoneLayoutResponse]

--- a/src/domain/_027_warehouse_model/service.py
+++ b/src/domain/_027_warehouse_model/service.py
@@ -1,0 +1,319 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, func, update
+from typing import Optional, Any
+import math
+
+from src.domain._027_warehouse_model.models import Warehouse, WarehouseZone, BinLocation
+from src.domain._027_warehouse_model.schemas import (
+    WarehouseCreate, WarehouseUpdate, ZoneCreate, BinCreate, WarehouseLayoutResponse,
+    WarehouseResponse, ZoneResponse, BinResponse
+)
+from shared.types import PaginatedResponse
+from shared.errors import NotFoundError, DuplicateError, ValidationError
+from src.domain._027_warehouse_model.validators import (
+    validate_warehouse_exists, validate_zone_exists, validate_bin_code_unique_in_zone
+)
+
+
+async def create_warehouse(db: AsyncSession, data: WarehouseCreate) -> Warehouse:
+    """Create a new warehouse.
+
+    Args:
+        db: Database session.
+        data: Warehouse creation data.
+    Returns:
+        The created Warehouse record.
+    Raises:
+        DuplicateError: If a warehouse with the same code already exists.
+    """
+    stmt = select(Warehouse).where(Warehouse.code == data.code)
+    result = await db.execute(stmt)
+    if result.scalar_one_or_none() is not None:
+        raise DuplicateError("Warehouse with this code already exists.")
+
+    warehouse = Warehouse(**data.model_dump())
+    db.add(warehouse)
+    await db.flush()
+    await db.refresh(warehouse)
+    return warehouse
+
+
+async def update_warehouse(db: AsyncSession, warehouse_id: int, data: WarehouseUpdate) -> Warehouse:
+    """Update an existing warehouse.
+
+    Args:
+        db: Database session.
+        warehouse_id: ID of the warehouse to update.
+        data: Warehouse update data (partial).
+    Returns:
+        The updated Warehouse record.
+    Raises:
+        NotFoundError: If the warehouse does not exist.
+    """
+    await validate_warehouse_exists(db, warehouse_id)
+
+    stmt = select(Warehouse).where(Warehouse.id == warehouse_id)
+    result = await db.execute(stmt)
+    warehouse = result.scalar_one()
+
+    update_data = data.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(warehouse, key, value)
+
+    await db.flush()
+    await db.refresh(warehouse)
+    return warehouse
+
+
+async def get_warehouse(db: AsyncSession, warehouse_id: int) -> Warehouse:
+    """Get a warehouse by ID.
+
+    Args:
+        db: Database session.
+        warehouse_id: ID of the warehouse.
+    Returns:
+        The Warehouse record.
+    Raises:
+        NotFoundError: If the warehouse does not exist.
+    """
+    stmt = select(Warehouse).where(Warehouse.id == warehouse_id)
+    result = await db.execute(stmt)
+    warehouse = result.scalar_one_or_none()
+    if warehouse is None:
+        raise NotFoundError("Warehouse not found.")
+    return warehouse
+
+
+async def list_warehouses(
+    db: AsyncSession, is_active: Optional[bool] = None, page: int = 1, page_size: int = 50
+) -> PaginatedResponse[WarehouseResponse]:
+    """List warehouses with optional filtering.
+
+    Args:
+        db: Database session.
+        is_active: Optional filter by active status.
+        page: Page number.
+        page_size: Items per page.
+    Returns:
+        PaginatedResponse containing WarehouseResponse items.
+    """
+    stmt = select(Warehouse)
+    if is_active is not None:
+        stmt = stmt.where(Warehouse.is_active == is_active)
+
+    total_stmt = select(func.count()).select_from(stmt.subquery())
+    total = (await db.execute(total_stmt)).scalar() or 0
+
+    stmt = stmt.offset((page - 1) * page_size).limit(page_size)
+    result = await db.execute(stmt)
+    items = result.scalars().all()
+
+    return PaginatedResponse[WarehouseResponse](
+        items=[WarehouseResponse.model_validate(w) for w in items],
+        total=total,
+        page=page,
+        page_size=page_size,
+        total_pages=math.ceil(total / page_size) if total else 1
+    )
+
+
+async def create_zone(db: AsyncSession, warehouse_id: int, data: ZoneCreate) -> WarehouseZone:
+    """Create a zone within a warehouse.
+
+    Args:
+        db: Database session.
+        warehouse_id: ID of the parent warehouse.
+        data: Zone creation data.
+    Returns:
+        The created WarehouseZone record.
+    Raises:
+        NotFoundError: If the warehouse does not exist.
+        DuplicateError: If a zone with the same code already exists in the warehouse.
+    """
+    await validate_warehouse_exists(db, warehouse_id)
+
+    stmt = select(WarehouseZone).where(
+        WarehouseZone.warehouse_id == warehouse_id,
+        WarehouseZone.code == data.code
+    )
+    result = await db.execute(stmt)
+    if result.scalar_one_or_none() is not None:
+        raise DuplicateError("Zone with this code already exists in the warehouse.")
+
+    zone = WarehouseZone(warehouse_id=warehouse_id, **data.model_dump())
+    db.add(zone)
+    await db.flush()
+    await db.refresh(zone)
+    return zone
+
+
+async def list_zones(
+    db: AsyncSession, warehouse_id: int, page: int = 1, page_size: int = 50
+) -> PaginatedResponse[ZoneResponse]:
+    """List zones for a warehouse.
+
+    Args:
+        db: Database session.
+        warehouse_id: ID of the warehouse.
+        page: Page number.
+        page_size: Items per page.
+    Returns:
+        PaginatedResponse containing ZoneResponse items.
+    """
+    stmt = select(WarehouseZone).where(WarehouseZone.warehouse_id == warehouse_id)
+
+    total_stmt = select(func.count()).select_from(stmt.subquery())
+    total = (await db.execute(total_stmt)).scalar() or 0
+
+    stmt = stmt.offset((page - 1) * page_size).limit(page_size)
+    result = await db.execute(stmt)
+    items = result.scalars().all()
+
+    return PaginatedResponse[ZoneResponse](
+        items=[ZoneResponse.model_validate(z) for z in items],
+        total=total,
+        page=page,
+        page_size=page_size,
+        total_pages=math.ceil(total / page_size) if total else 1
+    )
+
+
+async def create_bin(db: AsyncSession, zone_id: int, data: BinCreate) -> BinLocation:
+    """Create a bin location within a zone.
+
+    Args:
+        db: Database session.
+        zone_id: ID of the parent zone.
+        data: Bin creation data.
+    Returns:
+        The created BinLocation record.
+    Raises:
+        NotFoundError: If the zone does not exist.
+        DuplicateError: If a bin with the same code already exists in the zone.
+        ValidationError: If current_usage > capacity.
+    """
+    await validate_zone_exists(db, zone_id)
+    await validate_bin_code_unique_in_zone(db, zone_id, data.code)
+
+    if data.capacity is not None and data.current_usage is not None:
+        if data.current_usage > data.capacity:
+            raise ValidationError("Current usage cannot exceed capacity.")
+
+    bin_loc = BinLocation(zone_id=zone_id, **data.model_dump())
+    db.add(bin_loc)
+    await db.flush()
+    await db.refresh(bin_loc)
+    return bin_loc
+
+
+async def list_bins(
+    db: AsyncSession, zone_id: int, page: int = 1, page_size: int = 50
+) -> PaginatedResponse[BinResponse]:
+    """List bin locations for a zone.
+
+    Args:
+        db: Database session.
+        zone_id: ID of the zone.
+        page: Page number.
+        page_size: Items per page.
+    Returns:
+        PaginatedResponse containing BinResponse items.
+    """
+    stmt = select(BinLocation).where(BinLocation.zone_id == zone_id)
+
+    total_stmt = select(func.count()).select_from(stmt.subquery())
+    total = (await db.execute(total_stmt)).scalar() or 0
+
+    stmt = stmt.offset((page - 1) * page_size).limit(page_size)
+    result = await db.execute(stmt)
+    items = result.scalars().all()
+
+    return PaginatedResponse[BinResponse](
+        items=[BinResponse.model_validate(b) for b in items],
+        total=total,
+        page=page,
+        page_size=page_size,
+        total_pages=math.ceil(total / page_size) if total else 1
+    )
+
+
+async def get_warehouse_layout(db: AsyncSession, warehouse_id: int) -> WarehouseLayoutResponse:
+    """Get the full warehouse layout (warehouse + zones + bins).
+
+    Returns a nested structure with the warehouse, all its zones,
+    and all bins within each zone.
+
+    Args:
+        db: Database session.
+        warehouse_id: ID of the warehouse.
+    Returns:
+        WarehouseLayoutResponse with nested zone/bin data.
+    Raises:
+        NotFoundError: If the warehouse does not exist.
+    """
+    await validate_warehouse_exists(db, warehouse_id)
+
+    w_stmt = select(Warehouse).where(Warehouse.id == warehouse_id)
+    warehouse = (await db.execute(w_stmt)).scalar_one()
+
+    z_stmt = select(WarehouseZone).where(WarehouseZone.warehouse_id == warehouse_id)
+    zones = (await db.execute(z_stmt)).scalars().all()
+
+    b_stmt = select(BinLocation).join(WarehouseZone).where(WarehouseZone.warehouse_id == warehouse_id)
+    bins = (await db.execute(b_stmt)).scalars().all()
+
+    bins_by_zone: dict[int, list[BinResponse]] = {}
+    for b in bins:
+        bins_by_zone.setdefault(b.zone_id, []).append(BinResponse.model_validate(b))
+
+    from src.domain._027_warehouse_model.schemas import ZoneLayoutResponse
+
+    zones_list = []
+    for z in zones:
+        z_dict = ZoneResponse.model_validate(z).model_dump()
+        z_dict["bins"] = bins_by_zone.get(z.id, [])
+        zones_list.append(ZoneLayoutResponse(**z_dict))
+
+    return WarehouseLayoutResponse(
+        warehouse=WarehouseResponse.model_validate(warehouse),
+        zones=zones_list
+    )
+
+
+async def deactivate_warehouse(db: AsyncSession, warehouse_id: int) -> Warehouse:
+    """Deactivate a warehouse and all its zones and bins.
+
+    Sets is_active=False on the warehouse, all zones, and all bins.
+
+    Args:
+        db: Database session.
+        warehouse_id: ID of the warehouse to deactivate.
+    Returns:
+        The deactivated Warehouse record.
+    Raises:
+        NotFoundError: If the warehouse does not exist.
+    """
+    await validate_warehouse_exists(db, warehouse_id)
+
+    # Deactivate bins
+    b_stmt = update(BinLocation).where(
+        BinLocation.zone_id.in_(
+            select(WarehouseZone.id).where(WarehouseZone.warehouse_id == warehouse_id)
+        )
+    ).values(is_active=False)
+    await db.execute(b_stmt)
+
+    # Deactivate zones
+    z_stmt = update(WarehouseZone).where(WarehouseZone.warehouse_id == warehouse_id).values(is_active=False)
+    await db.execute(z_stmt)
+
+    # Deactivate warehouse
+    w_stmt = update(Warehouse).where(Warehouse.id == warehouse_id).values(is_active=False)
+    await db.execute(w_stmt)
+
+    # Return deactivated warehouse
+    stmt = select(Warehouse).where(Warehouse.id == warehouse_id)
+    warehouse = (await db.execute(stmt)).scalar_one()
+
+    await db.flush()
+    return warehouse

--- a/src/domain/_027_warehouse_model/tests/__init__.py
+++ b/src/domain/_027_warehouse_model/tests/__init__.py
@@ -1,0 +1,1 @@
+# Empty init

--- a/src/domain/_027_warehouse_model/tests/conftest.py
+++ b/src/domain/_027_warehouse_model/tests/conftest.py
@@ -1,0 +1,27 @@
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
+from sqlalchemy.pool import StaticPool
+from shared.types import Base
+
+# Create in-memory SQLite for testing using StaticPool to ensure connection is shared in tests
+engine = create_async_engine(
+    "sqlite+aiosqlite:///:memory:",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+    echo=False
+)
+TestingSessionLocal = async_sessionmaker(autocommit=False, autoflush=False, bind=engine, class_=AsyncSession, expire_on_commit=False)
+
+@pytest_asyncio.fixture(scope="function", autouse=True)
+async def setup_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+@pytest_asyncio.fixture(scope="function")
+async def db() -> AsyncSession:
+    async with TestingSessionLocal() as session:
+        yield session

--- a/src/domain/_027_warehouse_model/tests/test_models.py
+++ b/src/domain/_027_warehouse_model/tests/test_models.py
@@ -1,0 +1,90 @@
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from src.domain._027_warehouse_model.models import Warehouse, WarehouseZone, BinLocation
+from sqlalchemy.exc import IntegrityError
+from decimal import Decimal
+
+@pytest.mark.asyncio
+async def test_warehouse_model(db: AsyncSession):
+    w = Warehouse(code="WH01", name="Main WH", type="own")
+    db.add(w)
+    await db.commit()
+    await db.refresh(w)
+    assert w.id is not None
+    assert w.code == "WH01"
+    assert w.is_active is True
+
+@pytest.mark.asyncio
+async def test_warehouse_unique_code(db: AsyncSession):
+    w1 = Warehouse(code="WH02", name="W1", type="own")
+    w2 = Warehouse(code="WH02", name="W2", type="own")
+    db.add(w1)
+    await db.commit()
+    db.add(w2)
+    with pytest.raises(IntegrityError):
+        await db.commit()
+    await db.rollback()
+
+@pytest.mark.asyncio
+async def test_warehouse_zone_model(db: AsyncSession):
+    w = Warehouse(code="WH03", name="WH3", type="own")
+    db.add(w)
+    await db.commit()
+
+    z = WarehouseZone(warehouse_id=w.id, code="Z1", name="Zone 1", zone_type="storage")
+    db.add(z)
+    await db.commit()
+    assert z.id is not None
+    assert z.temperature_zone == "ambient"
+
+@pytest.mark.asyncio
+async def test_zone_unique_code_in_warehouse(db: AsyncSession):
+    w = Warehouse(code="WH04", name="WH4", type="own")
+    db.add(w)
+    await db.commit()
+
+    z1 = WarehouseZone(warehouse_id=w.id, code="Z1", name="Zone 1", zone_type="storage")
+    z2 = WarehouseZone(warehouse_id=w.id, code="Z1", name="Zone 2", zone_type="storage")
+    db.add(z1)
+    await db.commit()
+
+    db.add(z2)
+    with pytest.raises(IntegrityError):
+        await db.commit()
+    await db.rollback()
+
+@pytest.mark.asyncio
+async def test_bin_model(db: AsyncSession):
+    w = Warehouse(code="WH05", name="WH5", type="own")
+    db.add(w)
+    await db.commit()
+
+    z = WarehouseZone(warehouse_id=w.id, code="Z1", name="Zone 1", zone_type="storage")
+    db.add(z)
+    await db.commit()
+
+    b = BinLocation(zone_id=z.id, code="B1", name="Bin 1", capacity=Decimal("100.5"), current_usage=Decimal("10.0"))
+    db.add(b)
+    await db.commit()
+    assert b.id is not None
+    assert b.capacity == Decimal("100.5")
+
+@pytest.mark.asyncio
+async def test_bin_unique_code_in_zone(db: AsyncSession):
+    w = Warehouse(code="WH06", name="WH6", type="own")
+    db.add(w)
+    await db.commit()
+
+    z = WarehouseZone(warehouse_id=w.id, code="Z1", name="Zone 1", zone_type="storage")
+    db.add(z)
+    await db.commit()
+
+    b1 = BinLocation(zone_id=z.id, code="B1", name="Bin 1")
+    b2 = BinLocation(zone_id=z.id, code="B1", name="Bin 2")
+    db.add(b1)
+    await db.commit()
+
+    db.add(b2)
+    with pytest.raises(IntegrityError):
+        await db.commit()
+    await db.rollback()

--- a/src/domain/_027_warehouse_model/tests/test_router.py
+++ b/src/domain/_027_warehouse_model/tests/test_router.py
@@ -1,0 +1,86 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from fastapi import FastAPI
+from src.domain._027_warehouse_model.router import router
+
+# A dummy app for router tests (we'll rely on the actual setup using fixtures if needed)
+# In this repo, e2e usually uses the actual app, or we can use the router and a DB dependency.
+# Assuming standard pytest setup in this repo injects an app or we can import it.
+# Let's import the full app if available or set it up here.
+from src.foundation._001_database.engine import get_db
+
+app = FastAPI()
+app.include_router(router)
+
+@pytest.mark.asyncio
+async def test_router_create_warehouse(db):
+    app.dependency_overrides[get_db] = lambda: db
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.post("/api/v1/warehouses", json={
+            "code": "R_WH01",
+            "name": "Router WH",
+            "type": "own"
+        })
+        assert res.status_code == 201
+        assert res.json()["code"] == "R_WH01"
+        wh_id = res.json()["id"]
+
+        # Test get warehouse
+        res2 = await client.get(f"/api/v1/warehouses/{wh_id}")
+        assert res2.status_code == 200
+        assert res2.json()["code"] == "R_WH01"
+
+        # Test update warehouse
+        res3 = await client.put(f"/api/v1/warehouses/{wh_id}", json={"name": "Updated R WH"})
+        assert res3.status_code == 200
+        assert res3.json()["name"] == "Updated R WH"
+
+        # Test list warehouses
+        res4 = await client.get("/api/v1/warehouses")
+        assert res4.status_code == 200
+        assert len(res4.json()["items"]) >= 1
+
+@pytest.mark.asyncio
+async def test_router_zones_and_bins(db):
+    app.dependency_overrides[get_db] = lambda: db
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res_w = await client.post("/api/v1/warehouses", json={
+            "code": "R_WH02",
+            "name": "Router WH 2",
+            "type": "own"
+        })
+        wh_id = res_w.json()["id"]
+
+        # Create zone
+        res_z = await client.post(f"/api/v1/warehouses/{wh_id}/zones", json={
+            "code": "Z1",
+            "name": "Zone 1",
+            "zone_type": "storage"
+        })
+        assert res_z.status_code == 201
+        z_id = res_z.json()["id"]
+
+        # List zones
+        res_zl = await client.get(f"/api/v1/warehouses/{wh_id}/zones")
+        assert res_zl.status_code == 200
+        assert len(res_zl.json()["items"]) == 1
+
+        # Create bin
+        res_b = await client.post(f"/api/v1/zones/{z_id}/bins", json={
+            "code": "B1",
+            "name": "Bin 1"
+        })
+        assert res_b.status_code == 201
+
+        # List bins
+        res_bl = await client.get(f"/api/v1/zones/{z_id}/bins")
+        assert res_bl.status_code == 200
+        assert len(res_bl.json()["items"]) == 1
+
+        # Get layout
+        res_l = await client.get(f"/api/v1/warehouses/{wh_id}/layout")
+        assert res_l.status_code == 200
+        layout = res_l.json()
+        assert layout["warehouse"]["id"] == wh_id
+        assert len(layout["zones"]) == 1
+        assert len(layout["zones"][0]["bins"]) == 1

--- a/src/domain/_027_warehouse_model/tests/test_service.py
+++ b/src/domain/_027_warehouse_model/tests/test_service.py
@@ -1,0 +1,116 @@
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from src.domain._027_warehouse_model import service
+from src.domain._027_warehouse_model.schemas import (
+    WarehouseCreate, WarehouseType, WarehouseUpdate,
+    ZoneCreate, ZoneType,
+    BinCreate
+)
+from shared.errors import DuplicateError, NotFoundError, ValidationError
+from decimal import Decimal
+
+@pytest.mark.asyncio
+async def test_create_warehouse(db: AsyncSession):
+    data = WarehouseCreate(code="S_WH01", name="S WH", type=WarehouseType.own)
+    w = await service.create_warehouse(db, data)
+    assert w.id is not None
+    assert w.code == "S_WH01"
+
+    with pytest.raises(DuplicateError):
+        await service.create_warehouse(db, data)
+
+@pytest.mark.asyncio
+async def test_update_warehouse(db: AsyncSession):
+    data = WarehouseCreate(code="S_WH02", name="S WH", type=WarehouseType.own)
+    w = await service.create_warehouse(db, data)
+
+    update_data = WarehouseUpdate(name="Updated WH")
+    updated = await service.update_warehouse(db, w.id, update_data)
+    assert updated.name == "Updated WH"
+    assert updated.code == "S_WH02"
+
+    with pytest.raises(NotFoundError):
+        await service.update_warehouse(db, 9999, update_data)
+
+@pytest.mark.asyncio
+async def test_list_warehouses(db: AsyncSession):
+    await service.create_warehouse(db, WarehouseCreate(code="S_WH03", name="WH3", type=WarehouseType.own))
+    await service.create_warehouse(db, WarehouseCreate(code="S_WH04", name="WH4", type=WarehouseType.own))
+
+    res = await service.list_warehouses(db, page=1, page_size=10)
+    assert res.total >= 2
+
+@pytest.mark.asyncio
+async def test_create_zone(db: AsyncSession):
+    w = await service.create_warehouse(db, WarehouseCreate(code="S_WH05", name="WH5", type=WarehouseType.own))
+
+    data = ZoneCreate(code="S_Z01", name="Zone 1", zone_type=ZoneType.storage)
+    z = await service.create_zone(db, w.id, data)
+    assert z.id is not None
+
+    with pytest.raises(NotFoundError):
+        await service.create_zone(db, 9999, data)
+
+    with pytest.raises(DuplicateError):
+        await service.create_zone(db, w.id, data)
+
+@pytest.mark.asyncio
+async def test_list_zones(db: AsyncSession):
+    w = await service.create_warehouse(db, WarehouseCreate(code="S_WH06", name="WH", type=WarehouseType.own))
+    await service.create_zone(db, w.id, ZoneCreate(code="Z1", name="Z1", zone_type=ZoneType.storage))
+
+    res = await service.list_zones(db, w.id, page=1, page_size=10)
+    assert res.total == 1
+
+@pytest.mark.asyncio
+async def test_create_bin(db: AsyncSession):
+    w = await service.create_warehouse(db, WarehouseCreate(code="S_WH07", name="WH", type=WarehouseType.own))
+    z = await service.create_zone(db, w.id, ZoneCreate(code="Z1", name="Z1", zone_type=ZoneType.storage))
+
+    data = BinCreate(code="B1", name="Bin 1", capacity=Decimal("100"), current_usage=Decimal("50"))
+    b = await service.create_bin(db, z.id, data)
+    assert b.id is not None
+
+    with pytest.raises(NotFoundError):
+        await service.create_bin(db, 9999, data)
+
+    with pytest.raises(DuplicateError):
+        await service.create_bin(db, z.id, data)
+
+    data2 = BinCreate(code="B2", name="B2", capacity=Decimal("10"), current_usage=Decimal("20"))
+    with pytest.raises(ValidationError):
+        await service.create_bin(db, z.id, data2)
+
+@pytest.mark.asyncio
+async def test_list_bins(db: AsyncSession):
+    w = await service.create_warehouse(db, WarehouseCreate(code="S_WH08", name="WH", type=WarehouseType.own))
+    z = await service.create_zone(db, w.id, ZoneCreate(code="Z1", name="Z1", zone_type=ZoneType.storage))
+    await service.create_bin(db, z.id, BinCreate(code="B1", name="B1"))
+
+    res = await service.list_bins(db, z.id)
+    assert res.total == 1
+
+@pytest.mark.asyncio
+async def test_get_warehouse_layout(db: AsyncSession):
+    w = await service.create_warehouse(db, WarehouseCreate(code="S_WH09", name="WH", type=WarehouseType.own))
+    z1 = await service.create_zone(db, w.id, ZoneCreate(code="Z1", name="Z1", zone_type=ZoneType.storage))
+    await service.create_bin(db, z1.id, BinCreate(code="B1", name="B1"))
+
+    layout = await service.get_warehouse_layout(db, w.id)
+    assert layout.warehouse.code == "S_WH09"
+    assert len(layout.zones) == 1
+    assert layout.zones[0].code == "Z1"
+    assert len(layout.zones[0].bins) == 1
+    assert layout.zones[0].bins[0].code == "B1"
+
+@pytest.mark.asyncio
+async def test_deactivate_warehouse(db: AsyncSession):
+    w = await service.create_warehouse(db, WarehouseCreate(code="S_WH10", name="WH", type=WarehouseType.own))
+    z = await service.create_zone(db, w.id, ZoneCreate(code="Z1", name="Z1", zone_type=ZoneType.storage))
+    b = await service.create_bin(db, z.id, BinCreate(code="B1", name="B1"))
+
+    await service.deactivate_warehouse(db, w.id)
+
+    # Checking DB directly using get or list
+    w_deact = await service.list_warehouses(db, is_active=False)
+    assert any(x.id == w.id for x in w_deact.items)

--- a/src/domain/_027_warehouse_model/tests/test_validators.py
+++ b/src/domain/_027_warehouse_model/tests/test_validators.py
@@ -1,0 +1,69 @@
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from src.domain._027_warehouse_model.validators import (
+    validate_warehouse_code_unique,
+    validate_warehouse_exists,
+    validate_zone_exists,
+    validate_bin_code_unique_in_zone
+)
+from shared.errors import ValidationError, NotFoundError, DuplicateError
+from src.domain._027_warehouse_model.models import Warehouse, WarehouseZone, BinLocation
+
+def test_validate_warehouse_code_unique():
+    assert validate_warehouse_code_unique("WH001") == "WH001"
+    assert validate_warehouse_code_unique(" WH002 ") == "WH002"
+    with pytest.raises(ValidationError):
+        validate_warehouse_code_unique("")
+    with pytest.raises(ValidationError):
+        validate_warehouse_code_unique("   ")
+
+@pytest.mark.asyncio
+async def test_validate_warehouse_exists(db: AsyncSession):
+    w = Warehouse(code="V_WH01", name="W", type="own")
+    db.add(w)
+    await db.commit()
+    await db.refresh(w)
+
+    await validate_warehouse_exists(db, w.id)
+
+    with pytest.raises(NotFoundError):
+        await validate_warehouse_exists(db, 99999)
+
+@pytest.mark.asyncio
+async def test_validate_zone_exists(db: AsyncSession):
+    w = Warehouse(code="V_WH02", name="W", type="own")
+    db.add(w)
+    await db.commit()
+
+    z = WarehouseZone(warehouse_id=w.id, code="V_Z01", name="Z", zone_type="storage")
+    db.add(z)
+    await db.commit()
+
+    await validate_zone_exists(db, z.id)
+
+    with pytest.raises(NotFoundError):
+        await validate_zone_exists(db, 99999)
+
+@pytest.mark.asyncio
+async def test_validate_bin_code_unique_in_zone(db: AsyncSession):
+    w = Warehouse(code="V_WH03", name="W", type="own")
+    db.add(w)
+    await db.commit()
+
+    z = WarehouseZone(warehouse_id=w.id, code="V_Z01", name="Z", zone_type="storage")
+    db.add(z)
+    await db.commit()
+
+    b = BinLocation(zone_id=z.id, code="V_B01", name="B")
+    db.add(b)
+    await db.commit()
+
+    # Existing bin code -> raises
+    with pytest.raises(DuplicateError):
+        await validate_bin_code_unique_in_zone(db, z.id, "V_B01")
+
+    # Same code but exclude id -> ok
+    await validate_bin_code_unique_in_zone(db, z.id, "V_B01", exclude_id=b.id)
+
+    # New code -> ok
+    await validate_bin_code_unique_in_zone(db, z.id, "V_B02")

--- a/src/domain/_027_warehouse_model/validators.py
+++ b/src/domain/_027_warehouse_model/validators.py
@@ -1,0 +1,66 @@
+from shared.errors import ValidationError, NotFoundError, DuplicateError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from typing import Optional
+from src.domain._027_warehouse_model.models import Warehouse, WarehouseZone, BinLocation
+
+def validate_warehouse_code_unique(value: str) -> str:
+    """Validate warehouse code format.
+
+    Args:
+        value: The warehouse code string.
+    Returns:
+        The validated code.
+    Raises:
+        ValidationError: If code format is invalid.
+    """
+    if not value or not value.strip():
+        raise ValidationError("Warehouse code cannot be empty.")
+    # Assuming valid code logic here (can be simple length or pattern)
+    return value.strip()
+
+async def validate_warehouse_exists(db: AsyncSession, warehouse_id: int) -> None:
+    """Validate that a warehouse exists.
+
+    Args:
+        db: Database session.
+        warehouse_id: Warehouse ID to check.
+    Raises:
+        NotFoundError: If warehouse does not exist.
+    """
+    stmt = select(Warehouse).where(Warehouse.id == warehouse_id)
+    result = await db.execute(stmt)
+    if result.scalar_one_or_none() is None:
+        raise NotFoundError("Warehouse not found.")
+
+async def validate_zone_exists(db: AsyncSession, zone_id: int) -> None:
+    """Validate that a zone exists.
+
+    Args:
+        db: Database session.
+        zone_id: Zone ID to check.
+    Raises:
+        NotFoundError: If zone does not exist.
+    """
+    stmt = select(WarehouseZone).where(WarehouseZone.id == zone_id)
+    result = await db.execute(stmt)
+    if result.scalar_one_or_none() is None:
+        raise NotFoundError("Zone not found.")
+
+async def validate_bin_code_unique_in_zone(db: AsyncSession, zone_id: int, code: str, exclude_id: Optional[int] = None) -> None:
+    """Validate bin code is unique within its zone.
+
+    Args:
+        db: Database session.
+        zone_id: Zone ID.
+        code: Bin code to check.
+        exclude_id: Bin ID to exclude (for updates).
+    Raises:
+        DuplicateError: If a bin with the same code already exists in the zone.
+    """
+    stmt = select(BinLocation).where(BinLocation.zone_id == zone_id, BinLocation.code == code)
+    if exclude_id is not None:
+        stmt = stmt.where(BinLocation.id != exclude_id)
+    result = await db.execute(stmt)
+    if result.scalar_one_or_none() is not None:
+        raise DuplicateError("A bin with this code already exists in the zone.")


### PR DESCRIPTION
Closes #37. Implements the Warehouse Master Data module including models, schemas, validators, service logic, API router, and tests.

---
*PR created automatically by Jules for task [15879043588207939018](https://jules.google.com/task/15879043588207939018) started by @muumuu8181*