### PR TITLE
Implement 035 Localization / i18n module

### DIFF
--- a/src/domain/_035_localization/README.md
+++ b/src/domain/_035_localization/README.md
@@ -1,0 +1,34 @@
+# Localization / i18n (035)
+
+This module provides multi-language support across the ERP system. It supports locale definitions, translation key-value pairs with module scoping, template-based lookup, and formatting utilities for dates, numbers, and currencies.
+
+## Features
+
+- **Locales**: Manage locales (`ja-JP`, `en-US`, etc.) and their formatting rules.
+- **Translations**: Key-value pairs grouped by module (`invoice.title`).
+- **Formatting**: Format dates, numbers, and currencies according to locale rules.
+- **Import/Export**: Easily manage translation files.
+
+## API Endpoints
+
+All endpoints are prefixed with `/api/v1/localization`.
+
+- `POST /locales` - Create a locale.
+- `GET /locales` - List locales.
+- `POST /translations` - Add a single translation entry.
+- `GET /translations` - Get translations for a specific locale (and optional module).
+- `POST /translations/lookup` - Look up a translation by key.
+- `POST /localization/format-date` - Format a date according to a locale.
+- `POST /localization/format-number` - Format a number according to a locale.
+- `POST /localization/format-currency` - Format currency according to a locale.
+- `POST /translations/export` - Export translations as a JSON-serializable map.
+- `POST /translations/import` - Import and upsert translations from a JSON map.
+
+## Usage Example
+
+```python
+from fastapi import APIRouter
+from src.domain._035_localization import router as localization_router
+
+app.include_router(localization_router)
+```

--- a/src/domain/_035_localization/__init__.py
+++ b/src/domain/_035_localization/__init__.py
@@ -1,0 +1,6 @@
+"""
+035 Localization - i18n module.
+"""
+from src.domain._035_localization.router import router
+
+__all__ = ["router"]

--- a/src/domain/_035_localization/models.py
+++ b/src/domain/_035_localization/models.py
@@ -1,0 +1,33 @@
+"""
+Models for the Localization / i18n module.
+"""
+from sqlalchemy import Boolean, Integer, String, Text, ForeignKey, UniqueConstraint, Index
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from shared.types import BaseModel
+
+
+class Locale(BaseModel):
+    __tablename__ = "locale"
+
+    code: Mapped[str] = mapped_column(String(5), unique=True, nullable=False)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    language: Mapped[str] = mapped_column(String(10), nullable=False)
+    country: Mapped[str] = mapped_column(String(10), nullable=False)
+    date_format: Mapped[str] = mapped_column(String(20), nullable=False)
+    number_format: Mapped[str] = mapped_column(String(20), nullable=False)
+    currency_code: Mapped[str] = mapped_column(String(3), nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+
+
+class Translation(BaseModel):
+    __tablename__ = "translation"
+    __table_args__ = (
+        UniqueConstraint("locale_id", "module", "key", name="uq_translation_locale_module_key"),
+        Index("ix_translation_locale_id", "locale_id"),
+        Index("ix_translation_module", "module"),
+    )
+
+    locale_id: Mapped[int] = mapped_column(Integer, ForeignKey("locale.id"), nullable=False)
+    module: Mapped[str] = mapped_column(String(50), nullable=False)
+    key: Mapped[str] = mapped_column(String(200), nullable=False)
+    value: Mapped[str] = mapped_column(Text, nullable=False)

--- a/src/domain/_035_localization/router.py
+++ b/src/domain/_035_localization/router.py
@@ -1,0 +1,144 @@
+"""
+Router for the Localization / i18n module.
+"""
+from typing import List, Optional
+from fastapi import APIRouter, Depends, Query, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from src.foundation._001_database.engine import get_db
+from src.domain._035_localization.models import Locale
+from src.domain._035_localization.schemas import (
+    LocaleCreate,
+    LocaleResponse,
+    TranslationCreate,
+    TranslationResponse,
+    TranslationLookup,
+    LocalizationExport,
+    FormatDateRequest,
+    FormatNumberRequest,
+    FormatCurrencyRequest,
+    TranslationExportRequest,
+    TranslationImportRequest,
+)
+from src.domain._035_localization import service
+from shared.errors import ValidationError, DuplicateError, NotFoundError
+
+
+router = APIRouter(prefix="/api/v1/localization", tags=["Localization"])
+
+
+async def seed_locales(db: AsyncSession) -> None:
+    """Pre-seed ja-JP and en-US locales if they don't exist."""
+    locales_to_seed = [
+        LocaleCreate(
+            code="ja-JP", name="日本語", language="ja", country="JP",
+            date_format="%Y年%m月%d日", number_format="#,###", currency_code="JPY"
+        ),
+        LocaleCreate(
+            code="en-US", name="English", language="en", country="US",
+            date_format="%m/%d/%Y", number_format="#,###.##", currency_code="USD"
+        )
+    ]
+
+    for loc_data in locales_to_seed:
+        result = await db.execute(select(Locale).filter(Locale.code == loc_data.code))
+        if not result.scalars().first():
+            try:
+                await service.create_locale(db, loc_data)
+            except (ValidationError, DuplicateError):
+                pass
+
+
+@router.post("/locales", response_model=LocaleResponse, status_code=201)
+async def create_locale_endpoint(data: LocaleCreate, db: AsyncSession = Depends(get_db)):
+    try:
+        return await service.create_locale(db, data)
+    except ValidationError as e:
+        raise HTTPException(status_code=422, detail=e.message)
+    except DuplicateError as e:
+        raise HTTPException(status_code=422, detail=e.message)
+
+
+@router.get("/locales", response_model=List[LocaleResponse])
+async def list_locales_endpoint(is_active: Optional[bool] = Query(None), db: AsyncSession = Depends(get_db)):
+    await seed_locales(db) # Ensure seed data exists
+    return await service.list_locales(db, is_active)
+
+
+@router.post("/translations", response_model=TranslationResponse, status_code=201)
+async def add_translation_endpoint(data: TranslationCreate, db: AsyncSession = Depends(get_db)):
+    try:
+        return await service.add_translation(db, data)
+    except ValidationError as e:
+        raise HTTPException(status_code=422, detail=e.message)
+    except DuplicateError as e:
+        raise HTTPException(status_code=422, detail=e.message)
+    except NotFoundError as e:
+        raise HTTPException(status_code=404, detail=e.message)
+
+
+@router.get("/translations", response_model=List[TranslationResponse])
+async def get_translations_endpoint(locale: str = Query(...), module: Optional[str] = Query(None), db: AsyncSession = Depends(get_db)):
+    try:
+        return await service.get_translations(db, locale_code=locale, module=module)
+    except NotFoundError as e:
+        raise HTTPException(status_code=404, detail=e.message)
+
+
+@router.post("/translations/lookup")
+async def lookup_translation_endpoint(data: TranslationLookup, db: AsyncSession = Depends(get_db)):
+    # Note: the issue mentions POST body matching this data
+    if not data.key:
+        raise HTTPException(status_code=422, detail="Key is required for lookup")
+    value = await service.translate(db, data.locale_code, data.key, data.default)
+    return {"value": value}
+
+
+@router.post("/format-date")
+async def format_date_endpoint(data: FormatDateRequest, db: AsyncSession = Depends(get_db)):
+    await seed_locales(db)
+    try:
+        formatted = await service.format_date(db, data.locale_code, data.value)
+        return {"formatted": formatted}
+    except NotFoundError as e:
+        raise HTTPException(status_code=404, detail=e.message)
+
+
+@router.post("/format-number")
+async def format_number_endpoint(data: FormatNumberRequest, db: AsyncSession = Depends(get_db)):
+    await seed_locales(db)
+    try:
+        formatted = await service.format_number(db, data.locale_code, data.value)
+        return {"formatted": formatted}
+    except NotFoundError as e:
+        raise HTTPException(status_code=404, detail=e.message)
+
+
+@router.post("/format-currency")
+async def format_currency_endpoint(data: FormatCurrencyRequest, db: AsyncSession = Depends(get_db)):
+    await seed_locales(db)
+    try:
+        formatted = await service.format_currency(db, data.locale_code, data.value)
+        return {"formatted": formatted}
+    except NotFoundError as e:
+        raise HTTPException(status_code=404, detail=e.message)
+
+
+@router.post("/translations/export", response_model=LocalizationExport)
+async def export_translations_endpoint(data: TranslationExportRequest, db: AsyncSession = Depends(get_db)):
+    try:
+        return await service.export_translations(db, data.locale_code, data.module)
+    except NotFoundError as e:
+        raise HTTPException(status_code=404, detail=e.message)
+
+
+@router.post("/translations/import")
+async def import_translations_endpoint(data: TranslationImportRequest, db: AsyncSession = Depends(get_db)):
+    try:
+        count = await service.import_translations(db, data.locale_code, data.translations, data.module)
+        return {"imported_count": count}
+    except NotFoundError as e:
+        raise HTTPException(status_code=404, detail=e.message)
+    except ValidationError as e:
+        raise HTTPException(status_code=422, detail=e.message)

--- a/src/domain/_035_localization/schemas.py
+++ b/src/domain/_035_localization/schemas.py
@@ -1,0 +1,75 @@
+"""
+Schemas for the Localization / i18n module.
+"""
+from typing import Dict, Optional
+from datetime import datetime, date
+from pydantic import Field, ConfigDict
+from shared.types import BaseSchema
+
+
+class LocaleCreate(BaseSchema):
+    code: str = Field(..., max_length=5)
+    name: str = Field(..., max_length=100)
+    language: str = Field(..., max_length=10)
+    country: str = Field(..., max_length=10)
+    date_format: str = Field(..., max_length=20)
+    number_format: str = Field(..., max_length=20)
+    currency_code: str = Field(..., max_length=3)
+    is_active: bool = True
+
+
+class LocaleResponse(LocaleCreate):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class TranslationCreate(BaseSchema):
+    locale_id: int
+    module: str = Field(..., max_length=50)
+    key: str = Field(..., max_length=200)
+    value: str
+
+
+class TranslationResponse(TranslationCreate):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class TranslationLookup(BaseSchema):
+    locale_code: str
+    module: Optional[str] = None
+    key: Optional[str] = None
+    default: Optional[str] = None
+
+
+class LocalizationExport(BaseSchema):
+    locale_code: str
+    translations: Dict[str, str]
+
+
+class FormatDateRequest(BaseSchema):
+    locale_code: str
+    value: date
+
+
+class FormatNumberRequest(BaseSchema):
+    locale_code: str
+    value: float
+
+
+class FormatCurrencyRequest(BaseSchema):
+    locale_code: str
+    value: float
+
+
+class TranslationExportRequest(BaseSchema):
+    locale_code: str
+    module: Optional[str] = None
+
+
+class TranslationImportRequest(BaseSchema):
+    locale_code: str
+    module: str
+    translations: Dict[str, str]

--- a/src/domain/_035_localization/service.py
+++ b/src/domain/_035_localization/service.py
@@ -1,0 +1,206 @@
+"""
+Service layer for the Localization / i18n module.
+"""
+from typing import Dict, List, Optional
+from datetime import date
+import locale as stdlib_locale
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from shared.errors import NotFoundError, ValidationError, DuplicateError
+from src.domain._035_localization.models import Locale, Translation
+from src.domain._035_localization.schemas import LocaleCreate, TranslationCreate, LocalizationExport
+from src.domain._035_localization.validators import (
+    validate_locale_code_format,
+    validate_key_format,
+    validate_value_not_empty,
+    validate_currency_code,
+    validate_locale_code_unique,
+    validate_translation_unique,
+)
+
+
+async def create_locale(db: AsyncSession, data: LocaleCreate) -> Locale:
+    """Create a new locale. Validates code format (xx-XX)."""
+    validate_locale_code_format(data.code)
+    validate_currency_code(data.currency_code)
+    await validate_locale_code_unique(db, data.code)
+
+    locale_obj = Locale(**data.model_dump())
+    db.add(locale_obj)
+    await db.commit()
+    await db.refresh(locale_obj)
+    return locale_obj
+
+
+async def list_locales(db: AsyncSession, is_active: Optional[bool] = None) -> List[Locale]:
+    """List all locales, optionally filtered by active status."""
+    stmt = select(Locale)
+    if is_active is not None:
+        stmt = stmt.filter(Locale.is_active == is_active)
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def add_translation(db: AsyncSession, data: TranslationCreate) -> Translation:
+    """Add a translation entry. Validates key format and value not empty."""
+    validate_key_format(data.key)
+    validate_value_not_empty(data.value)
+
+    # Ensure locale exists
+    result = await db.execute(select(Locale).filter(Locale.id == data.locale_id))
+    if not result.scalars().first():
+        raise NotFoundError("Locale", resource_id=str(data.locale_id))
+
+    await validate_translation_unique(db, data.locale_id, data.module, data.key)
+
+    translation_obj = Translation(**data.model_dump())
+    db.add(translation_obj)
+    await db.commit()
+    await db.refresh(translation_obj)
+    return translation_obj
+
+
+async def get_translations(db: AsyncSession, locale_code: str, module: Optional[str] = None) -> List[Translation]:
+    """Get translations for a locale, optionally filtered by module."""
+    locale_res = await db.execute(select(Locale).filter(Locale.code == locale_code))
+    locale_obj = locale_res.scalars().first()
+    if not locale_obj:
+        raise NotFoundError("Locale", resource_id=locale_code)
+
+    stmt = select(Translation).filter(Translation.locale_id == locale_obj.id)
+    if module:
+        stmt = stmt.filter(Translation.module == module)
+
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def get_translations_by_module(db: AsyncSession, locale_code: str, module: str) -> Dict[str, str]:
+    """Get translations as a key-value dict for a specific locale and module."""
+    translations = await get_translations(db, locale_code, module)
+    return {t.key: t.value for t in translations}
+
+
+async def translate(db: AsyncSession, locale_code: str, key: str, default: Optional[str] = None) -> str:
+    """Look up a single translation by key. Returns default or key if not found."""
+    locale_res = await db.execute(select(Locale).filter(Locale.code == locale_code))
+    locale_obj = locale_res.scalars().first()
+    if not locale_obj:
+        return default if default is not None else key
+
+    result = await db.execute(select(Translation).filter(
+        Translation.locale_id == locale_obj.id,
+        Translation.key == key
+    ))
+    translation_obj = result.scalars().first()
+
+    if translation_obj:
+        return translation_obj.value
+
+    return default if default is not None else key
+
+
+async def _get_locale_by_code(db: AsyncSession, code: str) -> Locale:
+    result = await db.execute(select(Locale).filter(Locale.code == code))
+    locale_obj = result.scalars().first()
+    if not locale_obj:
+        raise NotFoundError("Locale", resource_id=code)
+    return locale_obj
+
+
+async def format_date(db: AsyncSession, locale_code: str, value: date) -> str:
+    """Format a date according to locale settings."""
+    locale_obj = await _get_locale_by_code(db, locale_code)
+    return value.strftime(locale_obj.date_format)
+
+
+async def format_number(db: AsyncSession, locale_code: str, value: float) -> str:
+    """Format a number according to locale settings (thousands separator, decimal)."""
+    locale_obj = await _get_locale_by_code(db, locale_code)
+    fmt = locale_obj.number_format
+
+    # We will implement basic custom formatting or fallback
+    # The requirement specifically mentions support for "#,###.##" (en-US) or "#,###" (ja-JP)
+    # A simple approach for these specific string patterns:
+
+    if "." in fmt:
+        parts = fmt.split(".")
+        decimal_places = len(parts[1]) if parts[1] else 0
+    else:
+        decimal_places = 0
+
+    if "#,###" in fmt:
+        return f"{value:,.{decimal_places}f}"
+
+    # default python fallback
+    return f"{value:.{decimal_places}f}"
+
+
+async def format_currency(db: AsyncSession, locale_code: str, value: float) -> str:
+    """Format a currency value according to locale settings (symbol, decimals)."""
+    locale_obj = await _get_locale_by_code(db, locale_code)
+
+    number_str = await format_number(db, locale_code, value)
+
+    # Add currency code. If ja-JP -> ¥, en-US -> $ (simplified logic for standard cases)
+    # The requirement just says "according to locale settings".
+    # For a robust implementation, we map currency code to symbols
+    symbol_map = {
+        "JPY": "¥",
+        "USD": "$",
+        "EUR": "€",
+        "GBP": "£"
+    }
+    symbol = symbol_map.get(locale_obj.currency_code, locale_obj.currency_code + " ")
+
+    if locale_obj.currency_code == "JPY":
+        return f"{symbol}{number_str}"
+    elif locale_obj.currency_code == "USD":
+        return f"{symbol}{number_str}"
+
+    return f"{symbol}{number_str}"
+
+
+async def export_translations(db: AsyncSession, locale_code: str, module: Optional[str] = None) -> LocalizationExport:
+    """Export translations as JSON-serializable dict."""
+    translations_list = await get_translations(db, locale_code, module)
+    translations_dict = {t.key: t.value for t in translations_list}
+    return LocalizationExport(locale_code=locale_code, translations=translations_dict)
+
+
+async def import_translations(db: AsyncSession, locale_code: str, data: Dict[str, str], module: str) -> int:
+    """Import translations from a key-value dict. Upserts existing entries.
+    Returns count of imported/updated translations.
+    """
+    locale_obj = await _get_locale_by_code(db, locale_code)
+
+    count = 0
+    for key, value in data.items():
+        validate_key_format(key)
+        validate_value_not_empty(value)
+
+        result = await db.execute(select(Translation).filter(
+            Translation.locale_id == locale_obj.id,
+            Translation.module == module,
+            Translation.key == key
+        ))
+        existing_translation = result.scalars().first()
+
+        if existing_translation:
+            if existing_translation.value != value:
+                existing_translation.value = value
+                count += 1
+        else:
+            new_translation = Translation(
+                locale_id=locale_obj.id,
+                module=module,
+                key=key,
+                value=value
+            )
+            db.add(new_translation)
+            count += 1
+
+    await db.commit()
+    return count

--- a/src/domain/_035_localization/tests/conftest.py
+++ b/src/domain/_035_localization/tests/conftest.py
@@ -1,0 +1,26 @@
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
+from sqlalchemy.pool import StaticPool
+from shared.types import Base
+
+# Setup an in-memory SQLite database for testing
+TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+
+engine = create_async_engine(TEST_DATABASE_URL, echo=False, poolclass=StaticPool)
+TestingSessionLocal = async_sessionmaker(
+    bind=engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+)
+
+@pytest_asyncio.fixture(scope="function")
+async def db() -> AsyncSession:
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with TestingSessionLocal() as session:
+        yield session
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)

--- a/src/domain/_035_localization/tests/test_models.py
+++ b/src/domain/_035_localization/tests/test_models.py
@@ -1,0 +1,124 @@
+"""
+Tests for localization models.
+"""
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from src.domain._035_localization.models import Locale, Translation
+
+
+@pytest.mark.asyncio
+async def test_locale_table_creation(db: AsyncSession):
+    locale = Locale(
+        code="fr-FR",
+        name="Français",
+        language="fr",
+        country="FR",
+        date_format="%d/%m/%Y",
+        number_format="#,###.##",
+        currency_code="EUR"
+    )
+    db.add(locale)
+    await db.commit()
+    await db.refresh(locale)
+
+    assert locale.id is not None
+    assert locale.code == "fr-FR"
+
+
+@pytest.mark.asyncio
+async def test_locale_unique_code(db: AsyncSession):
+    locale1 = Locale(
+        code="it-IT",
+        name="Italiano",
+        language="it",
+        country="IT",
+        date_format="%d/%m/%Y",
+        number_format="#.###,##",
+        currency_code="EUR"
+    )
+    db.add(locale1)
+    await db.commit()
+
+    locale2 = Locale(
+        code="it-IT",
+        name="Italian",
+        language="en",
+        country="IT",
+        date_format="%d/%m/%Y",
+        number_format="#.###,##",
+        currency_code="EUR"
+    )
+    db.add(locale2)
+    with pytest.raises(IntegrityError):
+        await db.commit()
+
+    await db.rollback()
+
+
+@pytest.mark.asyncio
+async def test_translation_table_creation_and_fk(db: AsyncSession):
+    locale = Locale(
+        code="de-DE",
+        name="Deutsch",
+        language="de",
+        country="DE",
+        date_format="%d.%m.%Y",
+        number_format="#.###,##",
+        currency_code="EUR"
+    )
+    db.add(locale)
+    await db.commit()
+    await db.refresh(locale)
+
+    trans = Translation(
+        locale_id=locale.id,
+        module="core",
+        key="core.greeting.hello",
+        value="Hallo"
+    )
+    db.add(trans)
+    await db.commit()
+    await db.refresh(trans)
+
+    assert trans.id is not None
+    assert trans.locale_id == locale.id
+
+
+@pytest.mark.asyncio
+async def test_translation_unique_constraint(db: AsyncSession):
+    locale = Locale(
+        code="es-ES",
+        name="Español",
+        language="es",
+        country="ES",
+        date_format="%d/%m/%Y",
+        number_format="#.###,##",
+        currency_code="EUR"
+    )
+    db.add(locale)
+    await db.commit()
+    await db.refresh(locale)
+
+    trans1 = Translation(
+        locale_id=locale.id,
+        module="invoice",
+        key="invoice.title.main",
+        value="Factura"
+    )
+    db.add(trans1)
+    await db.commit()
+
+    trans2 = Translation(
+        locale_id=locale.id,
+        module="invoice",
+        key="invoice.title.main",
+        value="Factura de Venta"
+    )
+    db.add(trans2)
+    with pytest.raises(IntegrityError):
+        await db.commit()
+
+    await db.rollback()

--- a/src/domain/_035_localization/tests/test_router.py
+++ b/src/domain/_035_localization/tests/test_router.py
@@ -1,0 +1,140 @@
+"""
+Tests for localization router.
+"""
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient, ASGITransport
+from fastapi import FastAPI
+from sqlalchemy.ext.asyncio import AsyncSession
+from src.domain._035_localization.router import router
+from src.foundation._001_database.engine import get_db
+
+app = FastAPI()
+app.include_router(router)
+
+
+@pytest_asyncio.fixture
+async def client(db: AsyncSession) -> AsyncClient:
+    app.dependency_overrides[get_db] = lambda: db
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_locales_endpoints(client: AsyncClient, db: AsyncSession):
+    # Ensure seed locales exist
+    res = await client.get("/api/v1/localization/locales")
+    assert res.status_code == 200
+    assert len(res.json()) >= 2
+
+    # Create new
+    payload = {
+        "code": "es-MX",
+        "name": "Spanish (Mexico)",
+        "language": "es",
+        "country": "MX",
+        "date_format": "%d/%m/%Y",
+        "number_format": "#,###.##",
+        "currency_code": "MXN",
+        "is_active": True
+    }
+    create_res = await client.post("/api/v1/localization/locales", json=payload)
+    assert create_res.status_code == 201
+    assert create_res.json()["code"] == "es-MX"
+
+    # Invalid create
+    bad_payload = payload.copy()
+    bad_payload["code"] = "es-mexico"
+    bad_res = await client.post("/api/v1/localization/locales", json=bad_payload)
+    assert bad_res.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_translations_endpoints(client: AsyncClient, db: AsyncSession):
+    # Add translation (using pre-seeded en-US)
+    locales_res = await client.get("/api/v1/localization/locales")
+    en_us_id = next(loc["id"] for loc in locales_res.json() if loc["code"] == "en-US")
+
+    trans_payload = {
+        "locale_id": en_us_id,
+        "module": "core",
+        "key": "core.test.endpoint",
+        "value": "Endpoint Test"
+    }
+
+    post_res = await client.post("/api/v1/localization/translations", json=trans_payload)
+    assert post_res.status_code == 201
+    assert post_res.json()["value"] == "Endpoint Test"
+
+    # Get translations
+    get_res = await client.get("/api/v1/localization/translations?locale=en-US&module=core")
+    assert get_res.status_code == 200
+    assert len(get_res.json()) >= 1
+
+    # Lookup
+    lookup_payload = {
+        "locale_code": "en-US",
+        "module": "core",
+        "key": "core.test.endpoint",
+        "default": "Default"
+    }
+    lookup_res = await client.post("/api/v1/localization/translations/lookup", json=lookup_payload)
+    assert lookup_res.status_code == 200
+    assert lookup_res.json()["value"] == "Endpoint Test"
+
+
+@pytest.mark.asyncio
+async def test_format_endpoints(client: AsyncClient, db: AsyncSession):
+    # Wait for seed to finish if necessary by calling GET locales
+    await client.get("/api/v1/localization/locales")
+
+    date_res = await client.post("/api/v1/localization/format-date", json={
+        "locale_code": "ja-JP",
+        "value": "2025-01-15"
+    })
+    assert date_res.status_code == 200
+    assert date_res.json()["formatted"] == "2025年01月15日"
+
+    num_res = await client.post("/api/v1/localization/format-number", json={
+        "locale_code": "ja-JP",
+        "value": 1234567.89
+    })
+    assert num_res.status_code == 200
+    assert num_res.json()["formatted"] == "1,234,568"
+
+    cur_res = await client.post("/api/v1/localization/format-currency", json={
+        "locale_code": "ja-JP",
+        "value": 100000
+    })
+    assert cur_res.status_code == 200
+    assert cur_res.json()["formatted"] == "¥100,000"
+
+
+@pytest.mark.asyncio
+async def test_import_export_endpoints(client: AsyncClient, db: AsyncSession):
+    # Ensure seed
+    await client.get("/api/v1/localization/locales")
+
+    import_payload = {
+        "locale_code": "ja-JP",
+        "module": "invoice",
+        "translations": {
+            "invoice.title.main": "請求書",
+            "invoice.status.paid": "支払済"
+        }
+    }
+
+    import_res = await client.post("/api/v1/localization/translations/import", json=import_payload)
+    assert import_res.status_code == 200
+    assert import_res.json()["imported_count"] == 2
+
+    export_payload = {
+        "locale_code": "ja-JP",
+        "module": "invoice"
+    }
+    export_res = await client.post("/api/v1/localization/translations/export", json=export_payload)
+    assert export_res.status_code == 200
+    data = export_res.json()
+    assert data["locale_code"] == "ja-JP"
+    assert data["translations"]["invoice.title.main"] == "請求書"

--- a/src/domain/_035_localization/tests/test_service.py
+++ b/src/domain/_035_localization/tests/test_service.py
@@ -1,0 +1,268 @@
+"""
+Tests for localization service.
+"""
+from datetime import date
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from shared.errors import ValidationError, DuplicateError, NotFoundError
+from src.domain._035_localization import service
+from src.domain._035_localization.schemas import LocaleCreate, TranslationCreate
+
+
+@pytest.mark.asyncio
+async def test_create_locale_success(db: AsyncSession):
+    data = LocaleCreate(
+        code="zh-CN",
+        name="Chinese",
+        language="zh",
+        country="CN",
+        date_format="%Y-%m-%d",
+        number_format="#,###.##",
+        currency_code="CNY"
+    )
+    locale = await service.create_locale(db, data)
+    assert locale.id is not None
+    assert locale.code == "zh-CN"
+
+
+@pytest.mark.asyncio
+async def test_create_locale_invalid_code_format(db: AsyncSession):
+    data = LocaleCreate(
+        code="ZH-cn",
+        name="Chinese",
+        language="zh",
+        country="CN",
+        date_format="%Y-%m-%d",
+        number_format="#,###.##",
+        currency_code="CNY"
+    )
+    with pytest.raises(ValidationError):
+        await service.create_locale(db, data)
+
+
+@pytest.mark.asyncio
+async def test_create_locale_duplicate_code(db: AsyncSession):
+    data = LocaleCreate(
+        code="ko-KR",
+        name="Korean",
+        language="ko",
+        country="KR",
+        date_format="%Y-%m-%d",
+        number_format="#,###",
+        currency_code="KRW"
+    )
+    await service.create_locale(db, data)
+
+    with pytest.raises(DuplicateError):
+        await service.create_locale(db, data)
+
+
+@pytest.mark.asyncio
+async def test_list_locales(db: AsyncSession):
+    await service.create_locale(db, LocaleCreate(
+        code="ru-RU", name="Russian", language="ru", country="RU",
+        date_format="%d.%m.%Y", number_format="# ###,##", currency_code="RUB", is_active=True
+    ))
+    await service.create_locale(db, LocaleCreate(
+        code="th-TH", name="Thai", language="th", country="TH",
+        date_format="%d/%m/%Y", number_format="#,###.##", currency_code="THB", is_active=False
+    ))
+
+    locales = await service.list_locales(db)
+    assert len(locales) >= 2
+
+    active_locales = await service.list_locales(db, is_active=True)
+    assert all(l.is_active for l in active_locales)
+
+
+@pytest.mark.asyncio
+async def test_add_translation_success(db: AsyncSession):
+    locale = await service.create_locale(db, LocaleCreate(
+        code="en-GB", name="British English", language="en", country="GB",
+        date_format="%d/%m/%Y", number_format="#,###.##", currency_code="GBP"
+    ))
+
+    data = TranslationCreate(
+        locale_id=locale.id,
+        module="core",
+        key="core.greeting.hello",
+        value="Hello"
+    )
+    trans = await service.add_translation(db, data)
+    assert trans.id is not None
+    assert trans.value == "Hello"
+
+
+@pytest.mark.asyncio
+async def test_add_translation_invalid_key_format(db: AsyncSession):
+    locale = await service.create_locale(db, LocaleCreate(
+        code="en-AU", name="Aus English", language="en", country="AU",
+        date_format="%d/%m/%Y", number_format="#,###.##", currency_code="AUD"
+    ))
+
+    data = TranslationCreate(
+        locale_id=locale.id,
+        module="core",
+        key="invalid_key",
+        value="Hello"
+    )
+    with pytest.raises(ValidationError):
+        await service.add_translation(db, data)
+
+
+@pytest.mark.asyncio
+async def test_add_translation_empty_value(db: AsyncSession):
+    locale = await service.create_locale(db, LocaleCreate(
+        code="en-NZ", name="NZ English", language="en", country="NZ",
+        date_format="%d/%m/%Y", number_format="#,###.##", currency_code="NZD"
+    ))
+
+    data = TranslationCreate(
+        locale_id=locale.id,
+        module="core",
+        key="core.greeting.hello",
+        value=""
+    )
+    with pytest.raises(ValidationError):
+        await service.add_translation(db, data)
+
+
+@pytest.mark.asyncio
+async def test_get_translations(db: AsyncSession):
+    locale = await service.create_locale(db, LocaleCreate(
+        code="pt-BR", name="Portuguese", language="pt", country="BR",
+        date_format="%d/%m/%Y", number_format="#.###,##", currency_code="BRL"
+    ))
+
+    await service.add_translation(db, TranslationCreate(
+        locale_id=locale.id, module="sales", key="sales.invoice.title", value="Fatura"
+    ))
+    await service.add_translation(db, TranslationCreate(
+        locale_id=locale.id, module="hr", key="hr.employee.name", value="Nome do Empregado"
+    ))
+
+    trans_all = await service.get_translations(db, "pt-BR")
+    assert len(trans_all) == 2
+
+    trans_sales = await service.get_translations(db, "pt-BR", module="sales")
+    assert len(trans_sales) == 1
+    assert trans_sales[0].key == "sales.invoice.title"
+
+
+@pytest.mark.asyncio
+async def test_get_translations_by_module(db: AsyncSession):
+    locale = await service.create_locale(db, LocaleCreate(
+        code="pt-PT", name="Portuguese", language="pt", country="PT",
+        date_format="%d/%m/%Y", number_format="#.###,##", currency_code="EUR"
+    ))
+
+    await service.add_translation(db, TranslationCreate(
+        locale_id=locale.id, module="sales", key="sales.invoice.title", value="Fatura"
+    ))
+
+    trans_dict = await service.get_translations_by_module(db, "pt-PT", "sales")
+    assert trans_dict == {"sales.invoice.title": "Fatura"}
+
+
+@pytest.mark.asyncio
+async def test_translate(db: AsyncSession):
+    locale = await service.create_locale(db, LocaleCreate(
+        code="nl-NL", name="Dutch", language="nl", country="NL",
+        date_format="%d-%m-%Y", number_format="#.###,##", currency_code="EUR"
+    ))
+    await service.add_translation(db, TranslationCreate(
+        locale_id=locale.id, module="core", key="core.button.save", value="Opslaan"
+    ))
+
+    # Exists
+    val = await service.translate(db, "nl-NL", "core.button.save")
+    assert val == "Opslaan"
+
+    # Missing with default
+    val2 = await service.translate(db, "nl-NL", "core.button.cancel", default="Cancel")
+    assert val2 == "Cancel"
+
+    # Missing without default
+    val3 = await service.translate(db, "nl-NL", "core.button.delete")
+    assert val3 == "core.button.delete"
+
+
+@pytest.mark.asyncio
+async def test_format_date(db: AsyncSession):
+    await service.create_locale(db, LocaleCreate(
+        code="ja-JP", name="Japanese", language="ja", country="JP",
+        date_format="%Y年%m月%d日", number_format="#,###", currency_code="JPY"
+    ))
+    await service.create_locale(db, LocaleCreate(
+        code="en-US", name="English", language="en", country="US",
+        date_format="%m/%d/%Y", number_format="#,###.##", currency_code="USD"
+    ))
+
+    d = date(2025, 1, 15)
+
+    res_ja = await service.format_date(db, "ja-JP", d)
+    assert res_ja == "2025年01月15日"
+
+    res_en = await service.format_date(db, "en-US", d)
+    assert res_en == "01/15/2025"
+
+
+@pytest.mark.asyncio
+async def test_format_number_and_currency(db: AsyncSession):
+    await service.create_locale(db, LocaleCreate(
+        code="ja-JP", name="Japanese", language="ja", country="JP",
+        date_format="%Y年%m月%d日", number_format="#,###", currency_code="JPY"
+    ))
+    await service.create_locale(db, LocaleCreate(
+        code="en-US", name="English", language="en", country="US",
+        date_format="%m/%d/%Y", number_format="#,###.##", currency_code="USD"
+    ))
+
+    val1 = 1234567.89
+
+    # Number format
+    res_ja_num = await service.format_number(db, "ja-JP", val1)
+    assert res_ja_num == "1,234,568"  # Rounded to 0 decimals for JPY
+
+    res_en_num = await service.format_number(db, "en-US", val1)
+    assert res_en_num == "1,234,567.89"
+
+    # Currency format
+    res_ja_cur = await service.format_currency(db, "ja-JP", 100000)
+    assert res_ja_cur == "¥100,000"
+
+    res_en_cur = await service.format_currency(db, "en-US", val1)
+    assert res_en_cur == "$1,234,567.89"
+
+
+@pytest.mark.asyncio
+async def test_export_import_translations(db: AsyncSession):
+    locale = await service.create_locale(db, LocaleCreate(
+        code="pl-PL", name="Polish", language="pl", country="PL",
+        date_format="%d.%m.%Y", number_format="# ###,##", currency_code="PLN"
+    ))
+
+    # Import
+    data_to_import = {
+        "invoice.title.main": "Faktura",
+        "invoice.status.paid": "Opłacona"
+    }
+    count = await service.import_translations(db, "pl-PL", data_to_import, "invoice")
+    assert count == 2
+
+    # Update existing via import
+    data_to_import_update = {
+        "invoice.title.main": "Faktura VAT",
+        "invoice.status.unpaid": "Nieopłacona"
+    }
+    count2 = await service.import_translations(db, "pl-PL", data_to_import_update, "invoice")
+    assert count2 == 2 # 1 updated, 1 new
+
+    # Export
+    export_res = await service.export_translations(db, "pl-PL", "invoice")
+    assert export_res.locale_code == "pl-PL"
+    assert "invoice.title.main" in export_res.translations
+    assert export_res.translations["invoice.title.main"] == "Faktura VAT"
+    assert export_res.translations["invoice.status.paid"] == "Opłacona"
+    assert export_res.translations["invoice.status.unpaid"] == "Nieopłacona"

--- a/src/domain/_035_localization/tests/test_validators.py
+++ b/src/domain/_035_localization/tests/test_validators.py
@@ -1,0 +1,75 @@
+"""
+Tests for localization validators.
+"""
+import pytest
+from shared.errors import ValidationError
+
+from src.domain._035_localization.validators import (
+    validate_locale_code_format,
+    validate_key_format,
+    validate_value_not_empty,
+    validate_currency_code
+)
+
+
+def test_validate_locale_code_format():
+    # Pass cases
+    validate_locale_code_format("ja-JP")
+    validate_locale_code_format("en-US")
+    validate_locale_code_format("fr-FR")
+
+    # Fail cases
+    with pytest.raises(ValidationError):
+        validate_locale_code_format("japanese")
+
+    with pytest.raises(ValidationError):
+        validate_locale_code_format("JA-jp")
+
+    with pytest.raises(ValidationError):
+        validate_locale_code_format("jJP")
+
+
+def test_validate_key_format():
+    # Pass cases
+    validate_key_format("invoice.title.main")
+    validate_key_format("core.auth.login_failed")
+
+    # Fail cases
+    with pytest.raises(ValidationError):
+        validate_key_format("Invoice")
+
+    with pytest.raises(ValidationError):
+        validate_key_format("invoice.title")
+
+    with pytest.raises(ValidationError):
+        validate_key_format("INV.TITLE.MAIN")
+
+
+def test_validate_value_not_empty():
+    # Pass cases
+    validate_value_not_empty("Valid translation")
+    validate_value_not_empty("   Valid   ")
+
+    # Fail cases
+    with pytest.raises(ValidationError):
+        validate_value_not_empty("")
+
+    with pytest.raises(ValidationError):
+        validate_value_not_empty("   ")
+
+
+def test_validate_currency_code():
+    # Pass cases
+    validate_currency_code("JPY")
+    validate_currency_code("USD")
+    validate_currency_code("EUR")
+
+    # Fail cases
+    with pytest.raises(ValidationError):
+        validate_currency_code("jpy")
+
+    with pytest.raises(ValidationError):
+        validate_currency_code("US")
+
+    with pytest.raises(ValidationError):
+        validate_currency_code("YEN1")

--- a/src/domain/_035_localization/validators.py
+++ b/src/domain/_035_localization/validators.py
@@ -1,0 +1,58 @@
+"""
+Validators for the Localization / i18n module.
+"""
+import re
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from shared.errors import ValidationError, DuplicateError
+
+from src.domain._035_localization.models import Locale, Translation
+
+
+LOCALE_CODE_PATTERN = re.compile(r"^[a-z]{2}-[A-Z]{2}$")
+KEY_FORMAT_PATTERN = re.compile(r"^[a-z_]+\.[a-z_]+\.[a-z_]+$")
+CURRENCY_CODE_PATTERN = re.compile(r"^[A-Z]{3}$")
+
+
+def validate_locale_code_format(code: str) -> None:
+    """Validate locale code matches xx-XX format."""
+    if not LOCALE_CODE_PATTERN.match(code):
+        raise ValidationError("Invalid locale code format. Expected xx-XX (e.g. ja-JP)", field="code")
+
+
+def validate_key_format(key: str) -> None:
+    """Validate translation key matches module.section.key format."""
+    if not KEY_FORMAT_PATTERN.match(key):
+        raise ValidationError("Invalid key format. Expected module.section.key (lowercase, underscores)", field="key")
+
+
+def validate_value_not_empty(value: str) -> None:
+    """Validate translation value is not empty."""
+    if not value or not str(value).strip():
+        raise ValidationError("Translation value cannot be empty", field="value")
+
+
+def validate_currency_code(currency_code: str) -> None:
+    """Validate currency code is a 3-letter ISO code."""
+    if not CURRENCY_CODE_PATTERN.match(currency_code):
+        raise ValidationError("Invalid currency code. Expected 3 uppercase letters (e.g. JPY, USD)", field="currency_code")
+
+
+async def validate_locale_code_unique(db: AsyncSession, code: str) -> None:
+    """Validate locale code is unique in the database."""
+    result = await db.execute(select(Locale).filter(Locale.code == code))
+    if result.scalars().first() is not None:
+        raise DuplicateError("Locale", key=code)
+
+
+async def validate_translation_unique(db: AsyncSession, locale_id: int, module: str, key: str) -> None:
+    """Validate (locale_id, module, key) combination is unique."""
+    result = await db.execute(
+        select(Translation).filter(
+            Translation.locale_id == locale_id,
+            Translation.module == module,
+            Translation.key == key
+        )
+    )
+    if result.scalars().first() is not None:
+        raise DuplicateError("Translation", key=f"{locale_id}-{module}-{key}")


### PR DESCRIPTION
Implemented the **Localization / i18n (035)** module.

Features included:
*   `Locale` and `Translation` entities properly structured with Pydantic schemas.
*   Service layer logic for translations, date formats, number formats, currency formats, and import/export capabilities.
*   FastAPI router with endpoints and pre-seed hooks to initialize `ja-JP` and `en-US` defaults cleanly.
*   Complete async test suites for models, services, routers, and validators.

---
*PR created automatically by Jules for task [18071502247002952478](https://jules.google.com/task/18071502247002952478) started by @muumuu8181*