### PR TITLE
feat: implement 035 localization / i18n module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 *.sqlite3
 .pytest_cache/
 .mypy_cache/
+.venv/

--- a/src/domain/_035_localization/README.md
+++ b/src/domain/_035_localization/README.md
@@ -1,0 +1,21 @@
+# Localization / i18n Module (035)
+
+This module handles:
+- Locales configuration (country, language, formatting preferences)
+- Translations mapping for the entire ERP
+- Utilities to format dates, numbers, and currencies according to user locales
+
+## Dependencies
+- Phase 0: `_001_database` (engine, sessions)
+- `shared.types`, `shared.errors`
+
+## Usage Example
+
+```python
+# Look up a translation
+title = await translate(db, locale_code="ja-JP", key="invoice.title.main", default="Invoice")
+
+# Format currency
+amount_str = await format_currency(db, locale_code="en-US", value=1234.56)
+# "$1,234.56"
+```

--- a/src/domain/_035_localization/__init__.py
+++ b/src/domain/_035_localization/__init__.py
@@ -1,0 +1,4 @@
+from src.domain._035_localization.router import router
+from src.domain._035_localization.models import Locale, Translation
+
+__all__ = ["router", "Locale", "Translation"]

--- a/src/domain/_035_localization/models.py
+++ b/src/domain/_035_localization/models.py
@@ -1,0 +1,31 @@
+from sqlalchemy import String, Integer, Boolean, Text, ForeignKey, UniqueConstraint, Index
+from sqlalchemy.orm import Mapped, mapped_column
+
+from shared.types import BaseModel
+
+
+class Locale(BaseModel):
+    __tablename__ = "locale"
+
+    code: Mapped[str] = mapped_column(String(5), unique=True, nullable=False)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    language: Mapped[str] = mapped_column(String(10), nullable=False)
+    country: Mapped[str] = mapped_column(String(10), nullable=False)
+    date_format: Mapped[str] = mapped_column(String(20), nullable=False)
+    number_format: Mapped[str] = mapped_column(String(20), nullable=False)
+    currency_code: Mapped[str] = mapped_column(String(3), nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+
+
+class Translation(BaseModel):
+    __tablename__ = "translation"
+    __table_args__ = (
+        UniqueConstraint("locale_id", "module", "key", name="uq_translation_locale_module_key"),
+        Index("ix_translation_locale_id", "locale_id"),
+        Index("ix_translation_module", "module"),
+    )
+
+    locale_id: Mapped[int] = mapped_column(Integer, ForeignKey("locale.id"), nullable=False)
+    module: Mapped[str] = mapped_column(String(50), nullable=False)
+    key: Mapped[str] = mapped_column(String(200), nullable=False)
+    value: Mapped[str] = mapped_column(Text, nullable=False)

--- a/src/domain/_035_localization/router.py
+++ b/src/domain/_035_localization/router.py
@@ -1,0 +1,86 @@
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from typing import Optional
+
+from src.foundation._001_database.engine import get_db
+from src.domain._035_localization.schemas import (
+    LocaleCreate,
+    LocaleResponse,
+    TranslationCreate,
+    TranslationResponse,
+    TranslationLookup,
+    LocalizationExport,
+    FormatDateRequest,
+    FormatNumberRequest,
+    FormatCurrencyRequest,
+    ExportTranslationsRequest,
+    ImportTranslationsRequest
+)
+from src.domain._035_localization import service
+
+router = APIRouter(prefix="/api/v1/localization", tags=["localization"])
+
+
+@router.post("/locales", response_model=LocaleResponse, status_code=status.HTTP_201_CREATED)
+async def create_locale(data: LocaleCreate, db: AsyncSession = Depends(get_db)):
+    """Create a locale."""
+    return await service.create_locale(db, data)
+
+
+@router.get("/locales", response_model=list[LocaleResponse])
+async def list_locales(is_active: Optional[bool] = None, db: AsyncSession = Depends(get_db)):
+    """List locales."""
+    return await service.list_locales(db, is_active)
+
+
+@router.post("/translations", response_model=TranslationResponse, status_code=status.HTTP_201_CREATED)
+async def add_translation(data: TranslationCreate, db: AsyncSession = Depends(get_db)):
+    """Add a translation."""
+    return await service.add_translation(db, data)
+
+
+@router.get("/translations", response_model=list[TranslationResponse])
+async def get_translations(
+    locale: str = Query(..., alias="locale"),
+    module: Optional[str] = None,
+    db: AsyncSession = Depends(get_db)
+):
+    """Get translations for a locale."""
+    return await service.get_translations(db, locale, module)
+
+
+@router.post("/translations/lookup")
+async def lookup_translation(data: TranslationLookup, db: AsyncSession = Depends(get_db)) -> str:
+    """Look up a translation."""
+    return await service.translate(db, data.locale_code, data.key, data.default)
+
+
+@router.post("/format-date")
+async def format_date(data: FormatDateRequest, db: AsyncSession = Depends(get_db)) -> str:
+    """Format a date."""
+    return await service.format_date(db, data.locale_code, data.value)
+
+
+@router.post("/format-number")
+async def format_number(data: FormatNumberRequest, db: AsyncSession = Depends(get_db)) -> str:
+    """Format a number."""
+    return await service.format_number(db, data.locale_code, data.value)
+
+
+@router.post("/format-currency")
+async def format_currency(data: FormatCurrencyRequest, db: AsyncSession = Depends(get_db)) -> str:
+    """Format a currency value."""
+    return await service.format_currency(db, data.locale_code, data.value)
+
+
+@router.post("/translations/export", response_model=LocalizationExport)
+async def export_translations(data: ExportTranslationsRequest, db: AsyncSession = Depends(get_db)):
+    """Export translations."""
+    return await service.export_translations(db, data.locale_code, data.module)
+
+
+@router.post("/translations/import")
+async def import_translations(data: ImportTranslationsRequest, db: AsyncSession = Depends(get_db)) -> dict:
+    """Import translations."""
+    count = await service.import_translations(db, data.locale_code, data.translations, data.module)
+    return {"imported": count}

--- a/src/domain/_035_localization/schemas.py
+++ b/src/domain/_035_localization/schemas.py
@@ -1,0 +1,72 @@
+from datetime import datetime, date
+from typing import Optional
+from pydantic import Field
+
+from shared.types import BaseSchema
+
+
+class LocaleCreate(BaseSchema):
+    code: str = Field(..., max_length=5)
+    name: str = Field(..., max_length=100)
+    language: str = Field(..., max_length=10)
+    country: str = Field(..., max_length=10)
+    date_format: str = Field(..., max_length=20)
+    number_format: str = Field(..., max_length=20)
+    currency_code: str = Field(..., max_length=3)
+    is_active: bool = True
+
+
+class LocaleResponse(LocaleCreate):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class TranslationCreate(BaseSchema):
+    locale_id: int
+    module: str = Field(..., max_length=50)
+    key: str = Field(..., max_length=200)
+    value: str
+
+
+class TranslationResponse(TranslationCreate):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class TranslationLookup(BaseSchema):
+    locale_code: str
+    key: str
+    default: Optional[str] = None
+
+
+class LocalizationExport(BaseSchema):
+    locale_code: str
+    translations: dict[str, str]
+
+
+class FormatDateRequest(BaseSchema):
+    locale_code: str
+    value: date
+
+
+class FormatNumberRequest(BaseSchema):
+    locale_code: str
+    value: float
+
+
+class FormatCurrencyRequest(BaseSchema):
+    locale_code: str
+    value: float
+
+
+class ImportTranslationsRequest(BaseSchema):
+    locale_code: str
+    module: str
+    translations: dict[str, str]
+
+
+class ExportTranslationsRequest(BaseSchema):
+    locale_code: str
+    module: Optional[str] = None

--- a/src/domain/_035_localization/service.py
+++ b/src/domain/_035_localization/service.py
@@ -1,0 +1,227 @@
+from datetime import date
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from shared.errors import NotFoundError, DuplicateError
+from src.domain._035_localization.models import Locale, Translation
+from src.domain._035_localization.schemas import LocaleCreate, TranslationCreate, LocalizationExport
+from src.domain._035_localization.validators import (
+    validate_locale_code,
+    validate_currency_code,
+    validate_translation_key,
+    validate_translation_value
+)
+
+
+async def create_locale(db: AsyncSession, data: LocaleCreate) -> Locale:
+    """Create a new locale. Validates code format (xx-XX)."""
+    validate_locale_code(data.code)
+    validate_currency_code(data.currency_code)
+
+    query = select(Locale).where(Locale.code == data.code)
+    result = await db.execute(query)
+    if result.scalar_one_or_none():
+        raise DuplicateError(f"Locale with code '{data.code}' already exists.")
+
+    locale = Locale(**data.model_dump())
+    db.add(locale)
+    try:
+        await db.commit()
+        await db.refresh(locale)
+    except IntegrityError:
+        await db.rollback()
+        raise DuplicateError(f"Locale with code '{data.code}' already exists.")
+
+    return locale
+
+
+async def list_locales(db: AsyncSession, is_active: bool | None = None) -> list[Locale]:
+    """List all locales, optionally filtered by active status."""
+    query = select(Locale)
+    if is_active is not None:
+        query = query.where(Locale.is_active == is_active)
+    result = await db.execute(query)
+    return list(result.scalars().all())
+
+
+async def add_translation(db: AsyncSession, data: TranslationCreate) -> Translation:
+    """Add a translation entry. Validates key format and value not empty."""
+    validate_translation_key(data.key)
+    validate_translation_value(data.value)
+
+    query = select(Translation).where(
+        Translation.locale_id == data.locale_id,
+        Translation.module == data.module,
+        Translation.key == data.key
+    )
+    result = await db.execute(query)
+    if result.scalar_one_or_none():
+        raise DuplicateError(f"Translation with key '{data.key}' already exists for this locale and module.")
+
+    translation = Translation(**data.model_dump())
+    db.add(translation)
+    try:
+        await db.commit()
+        await db.refresh(translation)
+    except IntegrityError:
+        await db.rollback()
+        raise DuplicateError(f"Translation with key '{data.key}' already exists for this locale and module.")
+
+    return translation
+
+
+async def get_translations(db: AsyncSession, locale_code: str, module: str | None = None) -> list[Translation]:
+    """Get translations for a locale, optionally filtered by module."""
+    locale_query = select(Locale).where(Locale.code == locale_code)
+    result = await db.execute(locale_query)
+    locale = result.scalar_one_or_none()
+    if not locale:
+        raise NotFoundError(f"Locale '{locale_code}' not found.")
+
+    query = select(Translation).where(Translation.locale_id == locale.id)
+    if module:
+        query = query.where(Translation.module == module)
+
+    result = await db.execute(query)
+    return list(result.scalars().all())
+
+
+async def get_translations_by_module(db: AsyncSession, locale_code: str, module: str) -> dict[str, str]:
+    """Get translations as a key-value dict for a specific locale and module."""
+    translations = await get_translations(db, locale_code, module)
+    return {t.key: t.value for t in translations}
+
+
+async def translate(db: AsyncSession, locale_code: str, key: str, default: str | None = None) -> str:
+    """Look up a single translation by key. Returns default or key if not found."""
+    locale_query = select(Locale).where(Locale.code == locale_code)
+    result = await db.execute(locale_query)
+    locale = result.scalar_one_or_none()
+    if not locale:
+        return default if default is not None else key
+
+    module = key.split('.')[0] if '.' in key else ''
+
+    query = select(Translation).where(
+        Translation.locale_id == locale.id,
+        Translation.module == module,
+        Translation.key == key
+    )
+    result = await db.execute(query)
+    translation = result.scalar_one_or_none()
+
+    if translation:
+        return translation.value
+    return default if default is not None else key
+
+
+async def format_date(db: AsyncSession, locale_code: str, value: date) -> str:
+    """Format a date according to locale settings."""
+    locale_query = select(Locale).where(Locale.code == locale_code)
+    result = await db.execute(locale_query)
+    locale = result.scalar_one_or_none()
+    if not locale:
+        raise NotFoundError(f"Locale '{locale_code}' not found.")
+
+    return value.strftime(locale.date_format)
+
+
+async def format_number(db: AsyncSession, locale_code: str, value: float) -> str:
+    """Format a number according to locale settings (thousands separator, decimal)."""
+    locale_query = select(Locale).where(Locale.code == locale_code)
+    result = await db.execute(locale_query)
+    locale = result.scalar_one_or_none()
+    if not locale:
+        raise NotFoundError(f"Locale '{locale_code}' not found.")
+
+    fmt = locale.number_format
+    if fmt == "#,###.##":
+        return f"{value:,.2f}"
+    elif fmt == "#,###":
+        return f"{int(value):,}"
+
+    return str(value)
+
+
+async def format_currency(db: AsyncSession, locale_code: str, value: float) -> str:
+    """Format a currency value according to locale settings (symbol, decimals)."""
+    locale_query = select(Locale).where(Locale.code == locale_code)
+    result = await db.execute(locale_query)
+    locale = result.scalar_one_or_none()
+    if not locale:
+        raise NotFoundError(f"Locale '{locale_code}' not found.")
+
+    if locale.currency_code == "JPY":
+        return f"¥{int(value):,}"
+    elif locale.currency_code == "USD":
+        return f"${value:,.2f}"
+
+    return f"{locale.currency_code} {value}"
+
+
+async def export_translations(db: AsyncSession, locale_code: str, module: str | None = None) -> LocalizationExport:
+    """Export translations as JSON-serializable dict."""
+    translations = await get_translations_by_module(db, locale_code, module) if module else {}
+    if not module:
+        all_trans = await get_translations(db, locale_code)
+        translations = {t.key: t.value for t in all_trans}
+
+    return LocalizationExport(locale_code=locale_code, translations=translations)
+
+
+async def import_translations(db: AsyncSession, locale_code: str, data: dict[str, str], module: str) -> int:
+    """Import translations from a key-value dict. Upserts existing entries.
+    Returns count of imported/updated translations.
+    """
+    locale_query = select(Locale).where(Locale.code == locale_code)
+    result = await db.execute(locale_query)
+    locale = result.scalar_one_or_none()
+    if not locale:
+        raise NotFoundError(f"Locale '{locale_code}' not found.")
+
+    count = 0
+    for key, value in data.items():
+        validate_translation_key(key)
+        validate_translation_value(value)
+
+        query = select(Translation).where(
+            Translation.locale_id == locale.id,
+            Translation.module == module,
+            Translation.key == key
+        )
+        result = await db.execute(query)
+        translation = result.scalar_one_or_none()
+
+        if translation:
+            translation.value = value
+        else:
+            new_trans = Translation(locale_id=locale.id, module=module, key=key, value=value)
+            db.add(new_trans)
+
+        count += 1
+
+    await db.commit()
+    return count
+
+
+async def seed_default_locales(db: AsyncSession) -> None:
+    """Seed default ja-JP and en-US locales."""
+    defaults = [
+        {
+            "code": "ja-JP", "name": "日本語", "language": "ja", "country": "JP",
+            "date_format": "%Y年%m月%d日", "number_format": "#,###", "currency_code": "JPY"
+        },
+        {
+            "code": "en-US", "name": "English", "language": "en", "country": "US",
+            "date_format": "%m/%d/%Y", "number_format": "#,###.##", "currency_code": "USD"
+        }
+    ]
+
+    for d in defaults:
+        query = select(Locale).where(Locale.code == d["code"])
+        result = await db.execute(query)
+        if not result.scalar_one_or_none():
+            db.add(Locale(**d))
+
+    await db.commit()

--- a/src/domain/_035_localization/tests/conftest.py
+++ b/src/domain/_035_localization/tests/conftest.py
@@ -1,0 +1,45 @@
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from fastapi.testclient import TestClient
+from httpx import AsyncClient
+
+from src.foundation._001_database.engine import create_engine, get_session_factory, get_db
+from src.domain._035_localization.models import BaseModel
+from src.domain._035_localization.router import router
+from fastapi import FastAPI
+
+
+app = FastAPI()
+app.include_router(router)
+
+
+@pytest.fixture
+async def db_engine():
+    engine = create_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(BaseModel.metadata.create_all)
+    yield engine
+    await engine.dispose()
+
+
+@pytest.fixture
+async def db_session(db_engine):
+    session_factory = get_session_factory(db_engine)
+    async with session_factory() as session:
+        yield session
+
+
+from httpx import ASGITransport
+
+@pytest.fixture
+async def client(db_session):
+    async def override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+    app.dependency_overrides.clear()

--- a/src/domain/_035_localization/tests/test_models.py
+++ b/src/domain/_035_localization/tests/test_models.py
@@ -1,0 +1,104 @@
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from src.domain._035_localization.models import Locale, Translation
+
+pytestmark = pytest.mark.asyncio
+
+async def test_locale_model(db_session: AsyncSession):
+    locale = Locale(
+        code="fr-FR",
+        name="Français",
+        language="fr",
+        country="FR",
+        date_format="%d/%m/%Y",
+        number_format="#,###.##",
+        currency_code="EUR"
+    )
+    db_session.add(locale)
+    await db_session.commit()
+    await db_session.refresh(locale)
+
+    assert locale.id is not None
+    assert locale.code == "fr-FR"
+
+async def test_locale_code_unique(db_session: AsyncSession):
+    locale1 = Locale(
+        code="es-ES",
+        name="Español",
+        language="es",
+        country="ES",
+        date_format="%d/%m/%Y",
+        number_format="#,###.##",
+        currency_code="EUR"
+    )
+    db_session.add(locale1)
+    await db_session.commit()
+
+    locale2 = Locale(
+        code="es-ES",
+        name="Spanish",
+        language="es",
+        country="ES",
+        date_format="%d/%m/%Y",
+        number_format="#,###.##",
+        currency_code="EUR"
+    )
+    db_session.add(locale2)
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+    await db_session.rollback()
+
+async def test_translation_model(db_session: AsyncSession):
+    locale = Locale(
+        code="de-DE",
+        name="Deutsch",
+        language="de",
+        country="DE",
+        date_format="%d.%m.%Y",
+        number_format="#,###.##",
+        currency_code="EUR"
+    )
+    db_session.add(locale)
+    await db_session.commit()
+    await db_session.refresh(locale)
+
+    translation = Translation(
+        locale_id=locale.id,
+        module="sales",
+        key="sales.order.title",
+        value="Kundenauftrag"
+    )
+    db_session.add(translation)
+    await db_session.commit()
+    await db_session.refresh(translation)
+
+    assert translation.id is not None
+    assert translation.value == "Kundenauftrag"
+    assert translation.locale_id == locale.id
+
+async def test_translation_unique_constraint(db_session: AsyncSession):
+    locale = Locale(
+        code="it-IT",
+        name="Italiano",
+        language="it",
+        country="IT",
+        date_format="%d/%m/%Y",
+        number_format="#,###.##",
+        currency_code="EUR"
+    )
+    db_session.add(locale)
+    await db_session.commit()
+    await db_session.refresh(locale)
+
+    trans1 = Translation(locale_id=locale.id, module="test", key="test.key", value="Val 1")
+    db_session.add(trans1)
+    await db_session.commit()
+
+    trans2 = Translation(locale_id=locale.id, module="test", key="test.key", value="Val 2")
+    db_session.add(trans2)
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+    await db_session.rollback()

--- a/src/domain/_035_localization/tests/test_router.py
+++ b/src/domain/_035_localization/tests/test_router.py
@@ -1,0 +1,128 @@
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.domain._035_localization.service import seed_default_locales
+
+pytestmark = pytest.mark.asyncio
+
+async def test_create_locale_endpoint(client: AsyncClient):
+    response = await client.post("/api/v1/localization/locales", json={
+        "code": "zh-CN",
+        "name": "Chinese",
+        "language": "zh",
+        "country": "CN",
+        "date_format": "%Y-%m-%d",
+        "number_format": "#,###.##",
+        "currency_code": "CNY"
+    })
+    assert response.status_code == 201
+    data = response.json()
+    assert data["code"] == "zh-CN"
+
+async def test_list_locales_endpoint(client: AsyncClient, db_session: AsyncSession):
+    await seed_default_locales(db_session)
+    response = await client.get("/api/v1/localization/locales")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) >= 2
+    codes = [l["code"] for l in data]
+    assert "ja-JP" in codes
+
+async def test_add_translation_endpoint(client: AsyncClient, db_session: AsyncSession):
+    await seed_default_locales(db_session)
+    response = await client.get("/api/v1/localization/locales")
+    locales = response.json()
+    ja_locale = next(l for l in locales if l["code"] == "ja-JP")
+
+    response = await client.post("/api/v1/localization/translations", json={
+        "locale_id": ja_locale["id"],
+        "module": "test",
+        "key": "test.key.name",
+        "value": "テスト"
+    })
+    assert response.status_code == 201
+    data = response.json()
+    assert data["value"] == "テスト"
+
+async def test_get_translations_endpoint(client: AsyncClient, db_session: AsyncSession):
+    await seed_default_locales(db_session)
+    # Add translation directly
+    response = await client.get("/api/v1/localization/locales")
+    locales = response.json()
+    en_locale = next(l for l in locales if l["code"] == "en-US")
+
+    await client.post("/api/v1/localization/translations", json={
+        "locale_id": en_locale["id"],
+        "module": "sales",
+        "key": "sales.order.title",
+        "value": "Sales Order"
+    })
+
+    response = await client.get("/api/v1/localization/translations?locale=en-US&module=sales")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) >= 1
+    assert data[0]["key"] == "sales.order.title"
+
+async def test_lookup_translation_endpoint(client: AsyncClient, db_session: AsyncSession):
+    await seed_default_locales(db_session)
+    response = await client.post("/api/v1/localization/translations/lookup", json={
+        "locale_code": "en-US",
+        "key": "non.existent.key",
+        "default": "Default Value"
+    })
+    assert response.status_code == 200
+    assert response.json() == "Default Value"
+
+async def test_format_date_endpoint(client: AsyncClient, db_session: AsyncSession):
+    await seed_default_locales(db_session)
+    response = await client.post("/api/v1/localization/format-date", json={
+        "locale_code": "ja-JP",
+        "value": "2025-01-15"
+    })
+    assert response.status_code == 200
+    assert response.json() == "2025年01月15日"
+
+async def test_format_number_endpoint(client: AsyncClient, db_session: AsyncSession):
+    await seed_default_locales(db_session)
+    response = await client.post("/api/v1/localization/format-number", json={
+        "locale_code": "en-US",
+        "value": 1234567.89
+    })
+    assert response.status_code == 200
+    assert response.json() == "1,234,567.89"
+
+async def test_format_currency_endpoint(client: AsyncClient, db_session: AsyncSession):
+    await seed_default_locales(db_session)
+    response = await client.post("/api/v1/localization/format-currency", json={
+        "locale_code": "ja-JP",
+        "value": 100000
+    })
+    assert response.status_code == 200
+    assert response.json() == "¥100,000"
+
+async def test_export_import_endpoints(client: AsyncClient, db_session: AsyncSession):
+    await seed_default_locales(db_session)
+
+    # Import
+    response = await client.post("/api/v1/localization/translations/import", json={
+        "locale_code": "ja-JP",
+        "module": "settings",
+        "translations": {
+            "settings.title.main": "設定",
+            "settings.button.save": "保存"
+        }
+    })
+    assert response.status_code == 200
+    assert response.json()["imported"] == 2
+
+    # Export
+    response = await client.post("/api/v1/localization/translations/export", json={
+        "locale_code": "ja-JP",
+        "module": "settings"
+    })
+    assert response.status_code == 200
+    data = response.json()
+    assert data["locale_code"] == "ja-JP"
+    assert data["translations"]["settings.button.save"] == "保存"

--- a/src/domain/_035_localization/tests/test_schemas.py
+++ b/src/domain/_035_localization/tests/test_schemas.py
@@ -1,0 +1,59 @@
+import pytest
+from pydantic import ValidationError
+from datetime import date
+
+from src.domain._035_localization.schemas import (
+    LocaleCreate,
+    TranslationCreate,
+    FormatDateRequest
+)
+
+def test_locale_create_schema():
+    # Valid
+    data = LocaleCreate(
+        code="ja-JP",
+        name="日本語",
+        language="ja",
+        country="JP",
+        date_format="%Y年%m月%d日",
+        number_format="#,###",
+        currency_code="JPY"
+    )
+    assert data.code == "ja-JP"
+
+    # Invalid - code too long
+    with pytest.raises(ValidationError):
+        LocaleCreate(
+            code="ja-JAPAN",
+            name="日本語",
+            language="ja",
+            country="JP",
+            date_format="%Y年%m月%d日",
+            number_format="#,###",
+            currency_code="JPY"
+        )
+
+def test_translation_create_schema():
+    data = TranslationCreate(
+        locale_id=1,
+        module="sales",
+        key="sales.order.title",
+        value="Sales Order"
+    )
+    assert data.module == "sales"
+
+    with pytest.raises(ValidationError):
+        TranslationCreate(
+            locale_id=1,
+            module="a" * 51,
+            key="sales.order.title",
+            value="Sales Order"
+        )
+
+def test_format_date_request():
+    data = FormatDateRequest(
+        locale_code="en-US",
+        value=date(2025, 1, 15)
+    )
+    assert data.locale_code == "en-US"
+    assert data.value == date(2025, 1, 15)

--- a/src/domain/_035_localization/tests/test_service.py
+++ b/src/domain/_035_localization/tests/test_service.py
@@ -1,0 +1,148 @@
+import pytest
+from datetime import date
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from shared.errors import DuplicateError, NotFoundError, ValidationError
+from src.domain._035_localization.models import Locale, Translation
+from src.domain._035_localization.schemas import LocaleCreate, TranslationCreate
+from src.domain._035_localization.service import (
+    create_locale,
+    list_locales,
+    add_translation,
+    get_translations,
+    get_translations_by_module,
+    translate,
+    format_date,
+    format_number,
+    format_currency,
+    export_translations,
+    import_translations,
+    seed_default_locales
+)
+
+pytestmark = pytest.mark.asyncio
+
+async def test_seed_default_locales(db_session: AsyncSession):
+    await seed_default_locales(db_session)
+    locales = await list_locales(db_session)
+    codes = [l.code for l in locales]
+    assert "ja-JP" in codes
+    assert "en-US" in codes
+
+async def test_create_locale(db_session: AsyncSession):
+    data = LocaleCreate(
+        code="fr-FR",
+        name="Français",
+        language="fr",
+        country="FR",
+        date_format="%d/%m/%Y",
+        number_format="#,###.##",
+        currency_code="EUR"
+    )
+    locale = await create_locale(db_session, data)
+    assert locale.id is not None
+    assert locale.code == "fr-FR"
+
+    # Duplicate
+    with pytest.raises(DuplicateError):
+        await create_locale(db_session, data)
+
+async def test_add_translation(db_session: AsyncSession):
+    await seed_default_locales(db_session)
+    locales = await list_locales(db_session)
+    ja_locale = next(l for l in locales if l.code == "ja-JP")
+
+    data = TranslationCreate(
+        locale_id=ja_locale.id,
+        module="invoice",
+        key="invoice.title.main",
+        value="請求書"
+    )
+    trans = await add_translation(db_session, data)
+    assert trans.id is not None
+    assert trans.value == "請求書"
+
+    # Duplicate
+    with pytest.raises(DuplicateError):
+        await add_translation(db_session, data)
+
+async def test_translate(db_session: AsyncSession):
+    await seed_default_locales(db_session)
+    locales = await list_locales(db_session)
+    en_locale = next(l for l in locales if l.code == "en-US")
+
+    await add_translation(db_session, TranslationCreate(
+        locale_id=en_locale.id,
+        module="sales",
+        key="sales.order.title",
+        value="Sales Order"
+    ))
+
+    val = await translate(db_session, "en-US", "sales.order.title")
+    assert val == "Sales Order"
+
+    # Default fallback
+    val_default = await translate(db_session, "en-US", "sales.missing.key", "Default Title")
+    assert val_default == "Default Title"
+
+    # Key fallback
+    val_key = await translate(db_session, "en-US", "sales.missing.key")
+    assert val_key == "sales.missing.key"
+
+async def test_format_date(db_session: AsyncSession):
+    await seed_default_locales(db_session)
+    d = date(2025, 1, 15)
+
+    ja_str = await format_date(db_session, "ja-JP", d)
+    assert ja_str == "2025年01月15日"
+
+    en_str = await format_date(db_session, "en-US", d)
+    assert en_str == "01/15/2025"
+
+async def test_format_number(db_session: AsyncSession):
+    await seed_default_locales(db_session)
+    num = 1234567.89
+
+    ja_str = await format_number(db_session, "ja-JP", num)
+    assert ja_str == "1,234,567"
+
+    en_str = await format_number(db_session, "en-US", num)
+    assert en_str == "1,234,567.89"
+
+async def test_format_currency(db_session: AsyncSession):
+    await seed_default_locales(db_session)
+    val = 100000.50
+
+    ja_str = await format_currency(db_session, "ja-JP", val)
+    assert ja_str == "¥100,000"
+
+    en_str = await format_currency(db_session, "en-US", val)
+    assert en_str == "$100,000.50"
+
+async def test_import_export_translations(db_session: AsyncSession):
+    await seed_default_locales(db_session)
+
+    import_data = {
+        "invoice.title.main": "請求書",
+        "invoice.status.paid": "支払済"
+    }
+    count = await import_translations(db_session, "ja-JP", import_data, "invoice")
+    assert count == 2
+
+    # Export specific module
+    exported = await export_translations(db_session, "ja-JP", "invoice")
+    assert exported.locale_code == "ja-JP"
+    assert "invoice.title.main" in exported.translations
+    assert exported.translations["invoice.status.paid"] == "支払済"
+
+    # Export all
+    exported_all = await export_translations(db_session, "ja-JP")
+    assert "invoice.title.main" in exported_all.translations
+
+    # Upsert test
+    import_data_updated = {
+        "invoice.status.paid": "支払い完了"
+    }
+    await import_translations(db_session, "ja-JP", import_data_updated, "invoice")
+    val = await translate(db_session, "ja-JP", "invoice.status.paid")
+    assert val == "支払い完了"

--- a/src/domain/_035_localization/tests/test_validators.py
+++ b/src/domain/_035_localization/tests/test_validators.py
@@ -1,0 +1,69 @@
+import pytest
+from shared.errors import ValidationError
+from src.domain._035_localization.validators import (
+    validate_locale_code,
+    validate_translation_key,
+    validate_translation_value,
+    validate_currency_code
+)
+
+def test_validate_locale_code():
+    # Pass
+    validate_locale_code("ja-JP")
+    validate_locale_code("en-US")
+    validate_locale_code("fr-FR")
+
+    # Fail
+    with pytest.raises(ValidationError):
+        validate_locale_code("japanese")
+    with pytest.raises(ValidationError):
+        validate_locale_code("JA-jp")
+    with pytest.raises(ValidationError):
+        validate_locale_code("jJP")
+    with pytest.raises(ValidationError):
+        validate_locale_code("en_US")
+
+
+def test_validate_translation_key():
+    # Pass
+    validate_translation_key("invoice.title.main")
+    validate_translation_key("sales_order.header.status")
+
+    # Fail
+    with pytest.raises(ValidationError):
+        validate_translation_key("Invoice")
+    with pytest.raises(ValidationError):
+        validate_translation_key("invoice.title")
+    with pytest.raises(ValidationError):
+        validate_translation_key("INV.TITLE.MAIN")
+    with pytest.raises(ValidationError):
+        validate_translation_key("invoice-title-main")
+
+
+def test_validate_translation_value():
+    # Pass
+    validate_translation_value("Hello")
+    validate_translation_value("こんにちは")
+
+    # Fail
+    with pytest.raises(ValidationError):
+        validate_translation_value("")
+    with pytest.raises(ValidationError):
+        validate_translation_value("   ")
+
+
+def test_validate_currency_code():
+    # Pass
+    validate_currency_code("JPY")
+    validate_currency_code("USD")
+    validate_currency_code("EUR")
+
+    # Fail
+    with pytest.raises(ValidationError):
+        validate_currency_code("JP")
+    with pytest.raises(ValidationError):
+        validate_currency_code("jpy")
+    with pytest.raises(ValidationError):
+        validate_currency_code("YEN1")
+    with pytest.raises(ValidationError):
+        validate_currency_code("123")

--- a/src/domain/_035_localization/validators.py
+++ b/src/domain/_035_localization/validators.py
@@ -1,0 +1,28 @@
+import re
+from typing import Optional
+
+from shared.errors import ValidationError
+
+
+def validate_locale_code(code: str) -> None:
+    """Validate locale code format (e.g., ja-JP)."""
+    if not re.match(r"^[a-z]{2}-[A-Z]{2}$", code):
+        raise ValidationError(f"Invalid locale code format: {code}. Expected format like 'ja-JP'.")
+
+
+def validate_translation_key(key: str) -> None:
+    """Validate translation key format (module.section.key)."""
+    if not re.match(r"^[a-z_]+\.[a-z_]+\.[a-z_]+$", key):
+        raise ValidationError(f"Invalid translation key format: {key}. Expected format like 'module.section.key'.")
+
+
+def validate_translation_value(value: str) -> None:
+    """Validate translation value is not empty."""
+    if not value or not value.strip():
+        raise ValidationError("Translation value cannot be empty.")
+
+
+def validate_currency_code(code: str) -> None:
+    """Validate currency code is a 3-letter ISO 4217 code."""
+    if not re.match(r"^[A-Z]{3}$", str(code)):
+        raise ValidationError(f"Invalid currency code format: {code}. Expected a 3-letter ISO 4217 code.")


### PR DESCRIPTION
This PR introduces the 035 Localization / i18n module as per the requirements in Issue #31. 

Included components:
- `Locale` and `Translation` database models with appropriate constraints.
- Validation logic for codes and patterns.
- Service operations providing CRUD logic and lookup functionality.
- Formatting services for localized date, number, and currency formats.
- Complete test coverage for the new module using `pytest` and `httpx`.
- Integration into the `api/v1/localization` router prefix.

---
*PR created automatically by Jules for task [16281216728756726424](https://jules.google.com/task/16281216728756726424) started by @muumuu8181*