### PR TITLE
Implement 011 Common Validators module

### DIFF
--- a/src/foundation/_011_validators/README.md
+++ b/src/foundation/_011_validators/README.md
@@ -1,0 +1,62 @@
+# 011 Common Validators
+
+This module provides validation capabilities for the ERP system, divided into two main categories:
+
+1.  **Static/Reusable Validators**: Pre-defined Python functions for common data validation (e.g., Japanese phone numbers, postal codes, emails). These can be directly imported and used in Pydantic schemas or other logic across the system.
+2.  **Dynamic Validation Rules**: A database-backed system for defining, updating, and evaluating validation rules at runtime (e.g., regex, ranges, specific allowed values).
+
+## 1. Reusable Validators
+
+You can import these directly into your module for quick validation:
+
+```python
+from src.foundation._011_validators.validators import (
+    validate_japanese_phone,
+    validate_postal_code,
+    validate_email,
+    check_japanese_phone  # Pydantic helper
+)
+
+# Usage in logic
+is_valid = validate_email("test@example.com")
+
+# Usage in Pydantic V2
+from typing import Annotated
+from pydantic import BaseModel, AfterValidator
+
+class UserProfile(BaseModel):
+    phone: Annotated[str, AfterValidator(check_japanese_phone)]
+```
+
+## 2. Dynamic Validation Rules (API & Service)
+
+Dynamic rules are stored in the database (`ValidationRule` model) and can be evaluated on the fly.
+
+### Supported Rule Types
+*   `regex`: Uses the `pattern` parameter to match the value.
+*   `range`: Uses `min` and `max` parameters to evaluate a numeric value.
+*   `length`: Uses `min` and `max` parameters to evaluate the length of a string.
+*   `in`: Uses `choices` (a list) to ensure the value is one of the allowed options.
+
+### Service Usage
+
+```python
+from src.foundation._011_validators import service
+
+# ... inside an async function ...
+result = await service.evaluate(db_session, rule_name="strict_password", value="MySecret123!")
+
+if not result.is_valid:
+    print(f"Validation failed: {result.error_message}")
+```
+
+### API Endpoints
+
+The module exposes a REST API to manage these rules:
+
+*   `GET /api/v1/validators/rules`: List rules.
+*   `POST /api/v1/validators/rules`: Create a rule.
+*   `GET /api/v1/validators/rules/{id}`: Get a specific rule.
+*   `PATCH /api/v1/validators/rules/{id}`: Update a rule.
+*   `DELETE /api/v1/validators/rules/{id}`: Delete a rule.
+*   `POST /api/v1/validators/evaluate`: Evaluate a value against a rule.

--- a/src/foundation/_011_validators/__init__.py
+++ b/src/foundation/_011_validators/__init__.py
@@ -1,0 +1,3 @@
+from src.foundation._011_validators.models import ValidationRule
+
+__all__ = ["ValidationRule"]

--- a/src/foundation/_011_validators/models.py
+++ b/src/foundation/_011_validators/models.py
@@ -1,0 +1,18 @@
+from typing import Any
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import String, Boolean, JSON
+from shared.types import BaseModel
+
+
+class ValidationRule(BaseModel):
+    """
+    Model representing a dynamic validation rule.
+    """
+    __tablename__ = "validation_rules"
+
+    name: Mapped[str] = mapped_column(String(50), unique=True, nullable=False)
+    description: Mapped[str] = mapped_column(String(200), nullable=True)
+    rule_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    parameters: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=True)
+    error_message: Mapped[str] = mapped_column(String(200), nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, server_default="1", nullable=False)

--- a/src/foundation/_011_validators/router.py
+++ b/src/foundation/_011_validators/router.py
@@ -1,0 +1,92 @@
+from typing import Annotated
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+try:
+    from src.foundation._001_database.dependencies import get_db
+except ImportError:
+    # Fallback dependency if database module is not yet available
+    async def get_db() -> AsyncSession:
+        raise RuntimeError("Database dependency is not configured.")
+
+from shared.types import PaginatedResponse
+from src.foundation._011_validators import service
+from src.foundation._011_validators.schemas import (
+    ValidationRuleCreate,
+    ValidationRuleUpdate,
+    ValidationRuleResponse,
+    ValidationRequest,
+    ValidationResult
+)
+
+router = APIRouter(prefix="/api/v1/validators", tags=["validators"])
+
+# Use an Annotated dependency for cleaner code
+DbSession = Annotated[AsyncSession, Depends(get_db)]
+
+@router.post("/rules", response_model=ValidationRuleResponse, status_code=status.HTTP_201_CREATED)
+async def create_rule(rule_data: ValidationRuleCreate, db: DbSession):
+    """
+    Create a new validation rule.
+    """
+    rule = await service.create_rule(db, rule_data)
+    return rule
+
+
+@router.get("/rules", response_model=PaginatedResponse[ValidationRuleResponse])
+async def list_rules(
+    db: DbSession,
+    skip: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=1000)
+):
+    """
+    List all validation rules.
+    """
+    items, total = await service.list_rules(db, skip=skip, limit=limit)
+
+    # Calculate total pages
+    total_pages = (total + limit - 1) // limit if limit > 0 else 0
+    page = (skip // limit) + 1 if limit > 0 else 1
+
+    return PaginatedResponse(
+        items=items,
+        total=total,
+        page=page,
+        page_size=limit,
+        total_pages=total_pages
+    )
+
+
+@router.get("/rules/{rule_id}", response_model=ValidationRuleResponse)
+async def get_rule(rule_id: int, db: DbSession):
+    """
+    Get a specific validation rule by ID.
+    """
+    rule = await service.get_rule(db, rule_id)
+    return rule
+
+
+@router.patch("/rules/{rule_id}", response_model=ValidationRuleResponse)
+async def update_rule(rule_id: int, rule_data: ValidationRuleUpdate, db: DbSession):
+    """
+    Update a validation rule.
+    """
+    rule = await service.update_rule(db, rule_id, rule_data)
+    return rule
+
+
+@router.delete("/rules/{rule_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_rule(rule_id: int, db: DbSession):
+    """
+    Delete a validation rule.
+    """
+    await service.delete_rule(db, rule_id)
+
+
+@router.post("/evaluate", response_model=ValidationResult)
+async def evaluate_value(request: ValidationRequest, db: DbSession):
+    """
+    Evaluate a value against a named validation rule.
+    """
+    result = await service.evaluate(db, request.rule_name, request.value)
+    return result

--- a/src/foundation/_011_validators/schemas.py
+++ b/src/foundation/_011_validators/schemas.py
@@ -1,0 +1,48 @@
+from typing import Any, Optional
+from datetime import datetime
+from pydantic import Field
+from shared.types import BaseSchema
+
+
+class ValidationRuleBase(BaseSchema):
+    """Base schema for validation rules."""
+    name: str = Field(..., max_length=50, description="Unique name of the validation rule")
+    description: Optional[str] = Field(None, max_length=200, description="Description of the rule")
+    rule_type: str = Field(..., max_length=50, description="Type of the rule (e.g., regex, range)")
+    parameters: Optional[dict[str, Any]] = Field(None, description="Rule specific parameters")
+    error_message: str = Field(..., max_length=200, description="Error message to display when validation fails")
+    is_active: bool = Field(True, description="Whether the rule is currently active")
+
+
+class ValidationRuleCreate(ValidationRuleBase):
+    """Schema for creating a new validation rule."""
+    pass
+
+
+class ValidationRuleUpdate(BaseSchema):
+    """Schema for updating an existing validation rule."""
+    name: Optional[str] = Field(None, max_length=50)
+    description: Optional[str] = Field(None, max_length=200)
+    rule_type: Optional[str] = Field(None, max_length=50)
+    parameters: Optional[dict[str, Any]] = Field(None)
+    error_message: Optional[str] = Field(None, max_length=200)
+    is_active: Optional[bool] = Field(None)
+
+
+class ValidationRuleResponse(ValidationRuleBase):
+    """Schema for a validation rule response, including DB fields."""
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class ValidationRequest(BaseSchema):
+    """Schema for requesting a validation check against a specific rule."""
+    rule_name: str = Field(..., description="Name of the validation rule to evaluate against")
+    value: Any = Field(..., description="Value to validate")
+
+
+class ValidationResult(BaseSchema):
+    """Schema for the result of a validation evaluation."""
+    is_valid: bool = Field(..., description="True if validation passed, False otherwise")
+    error_message: Optional[str] = Field(None, description="Error message if validation failed")

--- a/src/foundation/_011_validators/service.py
+++ b/src/foundation/_011_validators/service.py
@@ -1,0 +1,226 @@
+import re
+from typing import Any, Sequence
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.exc import IntegrityError
+
+from shared.errors import NotFoundError, DuplicateError, BusinessRuleError
+from src.foundation._011_validators.models import ValidationRule
+from src.foundation._011_validators.schemas import ValidationRuleCreate, ValidationRuleUpdate, ValidationResult
+
+
+async def get_rule(db: AsyncSession, rule_id: int) -> ValidationRule:
+    """
+    Retrieve a validation rule by its ID.
+
+    Args:
+        db: The async database session.
+        rule_id: The ID of the rule to retrieve.
+
+    Returns:
+        The ValidationRule object.
+
+    Raises:
+        NotFoundError: If the rule does not exist.
+    """
+    result = await db.execute(select(ValidationRule).filter(ValidationRule.id == rule_id))
+    rule = result.scalars().first()
+    if not rule:
+        raise NotFoundError("ValidationRule", str(rule_id))
+    return rule
+
+
+async def get_rule_by_name(db: AsyncSession, name: str) -> ValidationRule:
+    """
+    Retrieve a validation rule by its unique name.
+
+    Args:
+        db: The async database session.
+        name: The unique name of the rule.
+
+    Returns:
+        The ValidationRule object.
+
+    Raises:
+        NotFoundError: If the rule does not exist.
+    """
+    result = await db.execute(select(ValidationRule).filter(ValidationRule.name == name))
+    rule = result.scalars().first()
+    if not rule:
+        raise NotFoundError("ValidationRule", name)
+    return rule
+
+
+async def list_rules(db: AsyncSession, skip: int = 0, limit: int = 100) -> tuple[Sequence[ValidationRule], int]:
+    """
+    List validation rules with pagination.
+
+    Args:
+        db: The async database session.
+        skip: Number of records to skip.
+        limit: Maximum number of records to return.
+
+    Returns:
+        A tuple containing the list of ValidationRule objects and the total count.
+    """
+    # Get total count
+    count_stmt = select(func.count()).select_from(ValidationRule)
+    count_result = await db.execute(count_stmt)
+    total = count_result.scalar_one()
+
+    # Get items
+    stmt = select(ValidationRule).offset(skip).limit(limit)
+    result = await db.execute(stmt)
+    items = result.scalars().all()
+
+    return items, total
+
+
+async def create_rule(db: AsyncSession, rule_data: ValidationRuleCreate) -> ValidationRule:
+    """
+    Create a new validation rule.
+
+    Args:
+        db: The async database session.
+        rule_data: The data for the new rule.
+
+    Returns:
+        The created ValidationRule object.
+
+    Raises:
+        DuplicateError: If a rule with the same name already exists.
+    """
+    rule = ValidationRule(**rule_data.model_dump())
+    db.add(rule)
+    try:
+        await db.commit()
+        await db.refresh(rule)
+        return rule
+    except IntegrityError:
+        await db.rollback()
+        raise DuplicateError("ValidationRule", rule_data.name)
+
+
+async def update_rule(db: AsyncSession, rule_id: int, rule_data: ValidationRuleUpdate) -> ValidationRule:
+    """
+    Update an existing validation rule.
+
+    Args:
+        db: The async database session.
+        rule_id: The ID of the rule to update.
+        rule_data: The updated data for the rule.
+
+    Returns:
+        The updated ValidationRule object.
+
+    Raises:
+        NotFoundError: If the rule does not exist.
+        DuplicateError: If the new name already exists for another rule.
+    """
+    rule = await get_rule(db, rule_id)
+
+    update_data = rule_data.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(rule, key, value)
+
+    try:
+        await db.commit()
+        await db.refresh(rule)
+        return rule
+    except IntegrityError:
+        await db.rollback()
+        raise DuplicateError("ValidationRule", update_data.get('name', ''))
+
+
+async def delete_rule(db: AsyncSession, rule_id: int) -> bool:
+    """
+    Delete a validation rule.
+
+    Args:
+        db: The async database session.
+        rule_id: The ID of the rule to delete.
+
+    Returns:
+        True if the deletion was successful.
+
+    Raises:
+        NotFoundError: If the rule does not exist.
+    """
+    rule = await get_rule(db, rule_id)
+    await db.delete(rule)
+    await db.commit()
+    return True
+
+
+async def evaluate(db: AsyncSession, rule_name: str, value: Any) -> ValidationResult:
+    """
+    Evaluate a value against a specific validation rule.
+
+    Args:
+        db: The async database session.
+        rule_name: The name of the rule to evaluate against.
+        value: The value to evaluate.
+
+    Returns:
+        A ValidationResult indicating success or failure.
+
+    Raises:
+        NotFoundError: If the rule does not exist.
+        BusinessRuleError: If the rule is inactive or misconfigured.
+    """
+    rule = await get_rule_by_name(db, rule_name)
+
+    if not rule.is_active:
+        raise BusinessRuleError(f"Validation rule '{rule_name}' is inactive.", "INACTIVE_RULE")
+
+    try:
+        if rule.rule_type == 'regex':
+            pattern = rule.parameters.get('pattern') if rule.parameters else None
+            if not pattern:
+                raise BusinessRuleError("Regex rule missing 'pattern' parameter.", "INVALID_RULE_CONFIG")
+
+            is_valid = bool(re.match(pattern, str(value)))
+
+        elif rule.rule_type == 'range':
+            min_val = rule.parameters.get('min') if rule.parameters else None
+            max_val = rule.parameters.get('max') if rule.parameters else None
+
+            try:
+                numeric_val = float(value)
+            except (ValueError, TypeError):
+                return ValidationResult(is_valid=False, error_message=f"Value must be numeric. {rule.error_message}")
+
+            is_valid = True
+            if min_val is not None and numeric_val < float(min_val):
+                is_valid = False
+            if max_val is not None and numeric_val > float(max_val):
+                is_valid = False
+
+        elif rule.rule_type == 'length':
+            min_len = rule.parameters.get('min') if rule.parameters else None
+            max_len = rule.parameters.get('max') if rule.parameters else None
+
+            val_len = len(str(value))
+            is_valid = True
+
+            if min_len is not None and val_len < int(min_len):
+                is_valid = False
+            if max_len is not None and val_len > int(max_len):
+                is_valid = False
+
+        elif rule.rule_type == 'in':
+            choices = rule.parameters.get('choices', []) if rule.parameters else []
+            is_valid = value in choices
+
+        else:
+            raise BusinessRuleError(f"Unsupported rule type: {rule.rule_type}", "UNSUPPORTED_RULE_TYPE")
+
+        if is_valid:
+            return ValidationResult(is_valid=True, error_message=None)
+        else:
+            return ValidationResult(is_valid=False, error_message=rule.error_message)
+
+    except Exception as e:
+        if isinstance(e, BusinessRuleError):
+            raise e
+        return ValidationResult(is_valid=False, error_message=f"Evaluation error: {str(e)}")

--- a/src/foundation/_011_validators/tests/test_models.py
+++ b/src/foundation/_011_validators/tests/test_models.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+from src.foundation._011_validators.models import ValidationRule
+
+def test_validation_rule_model_init():
+    rule = ValidationRule(
+        name="test_rule",
+        description="A test rule",
+        rule_type="regex",
+        parameters={"pattern": "^[0-9]+$"},
+        error_message="Must be numbers only"
+    )
+
+    assert rule.name == "test_rule"
+    assert rule.description == "A test rule"
+    assert rule.rule_type == "regex"
+    assert rule.parameters == {"pattern": "^[0-9]+$"}
+    assert rule.error_message == "Must be numbers only"

--- a/src/foundation/_011_validators/tests/test_router.py
+++ b/src/foundation/_011_validators/tests/test_router.py
@@ -1,0 +1,81 @@
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient, ASGITransport
+from fastapi import FastAPI
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
+
+from shared.types import Base
+from src.foundation._011_validators.router import router, get_db
+
+app = FastAPI()
+app.include_router(router)
+
+engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+TestingSessionLocal = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+async def override_get_db():
+    async with TestingSessionLocal() as session:
+        yield session
+
+app.dependency_overrides[get_db] = override_get_db
+
+@pytest_asyncio.fixture(autouse=True)
+async def init_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+@pytest_asyncio.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+@pytest.mark.asyncio
+async def test_router_create_and_get_rule(client: AsyncClient):
+    # Create
+    create_data = {
+        "name": "test_rule",
+        "description": "test",
+        "rule_type": "regex",
+        "parameters": {"pattern": "^[0-9]+$"},
+        "error_message": "Numbers only",
+        "is_active": True
+    }
+    response = await client.post("/api/v1/validators/rules", json=create_data)
+    assert response.status_code == 201
+    data = response.json()
+    assert data["name"] == "test_rule"
+    rule_id = data["id"]
+
+    # Get
+    response = await client.get(f"/api/v1/validators/rules/{rule_id}")
+    assert response.status_code == 200
+    assert response.json()["name"] == "test_rule"
+
+    # List
+    response = await client.get("/api/v1/validators/rules")
+    assert response.status_code == 200
+    list_data = response.json()
+    assert list_data["total"] == 1
+    assert len(list_data["items"]) == 1
+
+    # Update
+    response = await client.patch(f"/api/v1/validators/rules/{rule_id}", json={"name": "updated_rule"})
+    assert response.status_code == 200
+    assert response.json()["name"] == "updated_rule"
+
+    # Evaluate
+    evaluate_data = {
+        "rule_name": "updated_rule",
+        "value": "123"
+    }
+    response = await client.post("/api/v1/validators/evaluate", json=evaluate_data)
+    assert response.status_code == 200
+    assert response.json()["is_valid"] is True
+
+    # Delete
+    response = await client.delete(f"/api/v1/validators/rules/{rule_id}")
+    assert response.status_code == 204

--- a/src/foundation/_011_validators/tests/test_schemas.py
+++ b/src/foundation/_011_validators/tests/test_schemas.py
@@ -1,0 +1,28 @@
+from pydantic import ValidationError as PydanticValidationError
+import pytest
+from src.foundation._011_validators.schemas import ValidationRuleCreate, ValidationRequest
+
+def test_validation_rule_create_schema_valid():
+    data = {
+        "name": "email_regex",
+        "description": "Checks email",
+        "rule_type": "regex",
+        "parameters": {"pattern": ".*@.*"},
+        "error_message": "Invalid email"
+    }
+    schema = ValidationRuleCreate(**data)
+    assert schema.name == "email_regex"
+    assert schema.is_active is True
+
+def test_validation_rule_create_schema_invalid():
+    with pytest.raises(PydanticValidationError):
+        ValidationRuleCreate(
+            name="a" * 51, # max_length 50
+            rule_type="regex",
+            error_message="Error"
+        )
+
+def test_validation_request_schema():
+    req = ValidationRequest(rule_name="my_rule", value=123)
+    assert req.rule_name == "my_rule"
+    assert req.value == 123

--- a/src/foundation/_011_validators/tests/test_service.py
+++ b/src/foundation/_011_validators/tests/test_service.py
@@ -1,0 +1,113 @@
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
+from shared.types import Base
+from shared.errors import NotFoundError, DuplicateError, BusinessRuleError
+from src.foundation._011_validators.models import ValidationRule
+from src.foundation._011_validators.schemas import ValidationRuleCreate, ValidationRuleUpdate
+from src.foundation._011_validators import service
+
+@pytest_asyncio.fixture
+async def async_db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    SessionLocal = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with SessionLocal() as session:
+        yield session
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+@pytest.mark.asyncio
+async def test_crud_validation_rule(async_db: AsyncSession):
+    # Create
+    rule_data = ValidationRuleCreate(
+        name="test_regex",
+        description="test",
+        rule_type="regex",
+        parameters={"pattern": "^[0-9]+$"},
+        error_message="Numbers only"
+    )
+    created_rule = await service.create_rule(async_db, rule_data)
+    assert created_rule.id is not None
+    assert created_rule.name == "test_regex"
+
+    # Get
+    fetched_rule = await service.get_rule(async_db, created_rule.id)
+    assert fetched_rule.id == created_rule.id
+
+    # List
+    items, total = await service.list_rules(async_db)
+    assert total == 1
+    assert len(items) == 1
+
+    # Update
+    update_data = ValidationRuleUpdate(name="updated_name")
+    updated_rule = await service.update_rule(async_db, created_rule.id, update_data)
+    assert updated_rule.name == "updated_name"
+
+    # Delete
+    await service.delete_rule(async_db, created_rule.id)
+    with pytest.raises(NotFoundError):
+        await service.get_rule(async_db, created_rule.id)
+
+@pytest.mark.asyncio
+async def test_evaluate_regex(async_db: AsyncSession):
+    rule = await service.create_rule(async_db, ValidationRuleCreate(
+        name="number_only",
+        rule_type="regex",
+        parameters={"pattern": "^[0-9]+$"},
+        error_message="Numbers only"
+    ))
+
+    res1 = await service.evaluate(async_db, "number_only", "123")
+    assert res1.is_valid is True
+
+    res2 = await service.evaluate(async_db, "number_only", "abc")
+    assert res2.is_valid is False
+    assert res2.error_message == "Numbers only"
+
+@pytest.mark.asyncio
+async def test_evaluate_range(async_db: AsyncSession):
+    rule = await service.create_rule(async_db, ValidationRuleCreate(
+        name="age_range",
+        rule_type="range",
+        parameters={"min": 18, "max": 65},
+        error_message="Age out of range"
+    ))
+
+    res1 = await service.evaluate(async_db, "age_range", 30)
+    assert res1.is_valid is True
+
+    res2 = await service.evaluate(async_db, "age_range", 10)
+    assert res2.is_valid is False
+
+    res3 = await service.evaluate(async_db, "age_range", 70)
+    assert res3.is_valid is False
+
+@pytest.mark.asyncio
+async def test_evaluate_length(async_db: AsyncSession):
+    rule = await service.create_rule(async_db, ValidationRuleCreate(
+        name="str_len",
+        rule_type="length",
+        parameters={"min": 2, "max": 5},
+        error_message="Invalid length"
+    ))
+
+    assert (await service.evaluate(async_db, "str_len", "abc")).is_valid is True
+    assert (await service.evaluate(async_db, "str_len", "a")).is_valid is False
+    assert (await service.evaluate(async_db, "str_len", "abcdef")).is_valid is False
+
+@pytest.mark.asyncio
+async def test_evaluate_in(async_db: AsyncSession):
+    rule = await service.create_rule(async_db, ValidationRuleCreate(
+        name="status_in",
+        rule_type="in",
+        parameters={"choices": ["draft", "published"]},
+        error_message="Invalid status"
+    ))
+
+    assert (await service.evaluate(async_db, "status_in", "draft")).is_valid is True
+    assert (await service.evaluate(async_db, "status_in", "archived")).is_valid is False

--- a/src/foundation/_011_validators/tests/test_validators.py
+++ b/src/foundation/_011_validators/tests/test_validators.py
@@ -1,0 +1,45 @@
+import pytest
+from datetime import date
+from src.foundation._011_validators.validators import (
+    validate_japanese_phone,
+    validate_postal_code,
+    validate_email,
+    validate_date_range,
+    check_japanese_phone,
+    check_postal_code,
+    check_email
+)
+
+def test_validate_japanese_phone():
+    assert validate_japanese_phone("090-1234-5678") is True
+    assert validate_japanese_phone("03-1234-5678") is True
+    assert validate_japanese_phone("09012345678") is True
+    assert validate_japanese_phone("invalid") is False
+    assert validate_japanese_phone("123-456-7890") is False # Invalid JP phone format
+
+def test_validate_postal_code():
+    assert validate_postal_code("123-4567") is True
+    assert validate_postal_code("1234567") is True
+    assert validate_postal_code("12-34567") is False
+
+def test_validate_email():
+    assert validate_email("test@example.com") is True
+    assert validate_email("invalid-email") is False
+
+def test_validate_date_range():
+    assert validate_date_range(date(2023, 1, 1), date(2023, 1, 2)) is True
+    assert validate_date_range(date(2023, 1, 2), date(2023, 1, 2)) is True
+    assert validate_date_range(date(2023, 1, 3), date(2023, 1, 2)) is False
+
+def test_pydantic_validators():
+    assert check_japanese_phone("090-1234-5678") == "090-1234-5678"
+    with pytest.raises(ValueError):
+        check_japanese_phone("invalid")
+
+    assert check_postal_code("123-4567") == "123-4567"
+    with pytest.raises(ValueError):
+        check_postal_code("invalid")
+
+    assert check_email("test@example.com") == "test@example.com"
+    with pytest.raises(ValueError):
+        check_email("invalid")

--- a/src/foundation/_011_validators/validators.py
+++ b/src/foundation/_011_validators/validators.py
@@ -1,0 +1,62 @@
+import re
+from datetime import date
+from typing import Any
+
+from shared.errors import ValidationError
+
+
+def validate_japanese_phone(phone: str) -> bool:
+    """
+    Validate a Japanese phone number format (hyphens optional).
+    Valid formats: 090-1234-5678, 03-1234-5678, 09012345678, etc.
+    """
+    pattern = re.compile(r"^(0\d{1,4}-?\d{1,4}-?\d{4})$")
+    return bool(pattern.match(phone))
+
+
+def validate_postal_code(postal_code: str) -> bool:
+    """
+    Validate Japanese postal code format (XXX-XXXX or XXXXXXX).
+    """
+    pattern = re.compile(r"^\d{3}-?\d{4}$")
+    return bool(pattern.match(postal_code))
+
+
+def validate_email(email: str) -> bool:
+    """
+    Basic email format validation.
+    """
+    pattern = re.compile(r"^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$")
+    return bool(pattern.match(email))
+
+
+def validate_date_range(start_date: date, end_date: date) -> bool:
+    """
+    Validate that start_date is before or equal to end_date.
+    """
+    return start_date <= end_date
+
+
+# Pydantic AfterValidator helpers
+def check_japanese_phone(v: Any) -> Any:
+    if not isinstance(v, str):
+        raise ValueError("Phone must be a string")
+    if not validate_japanese_phone(v):
+        raise ValueError("Invalid Japanese phone number format")
+    return v
+
+
+def check_postal_code(v: Any) -> Any:
+    if not isinstance(v, str):
+        raise ValueError("Postal code must be a string")
+    if not validate_postal_code(v):
+        raise ValueError("Invalid Japanese postal code format")
+    return v
+
+
+def check_email(v: Any) -> Any:
+    if not isinstance(v, str):
+        raise ValueError("Email must be a string")
+    if not validate_email(v):
+        raise ValueError("Invalid email format")
+    return v


### PR DESCRIPTION
Implementation for issue #10. Creates the `_011_validators` module within the `src/foundation/` phase. It adheres to all architectural rules (models, schemas, service, router, and comprehensive tests). It provides both static reusable validation functions and a database-backed dynamic rule evaluation system.

---
*PR created automatically by Jules for task [8380845411550858049](https://jules.google.com/task/8380845411550858049) started by @muumuu8181*