### PR TITLE
feat(domain): add 031_audit_log module

### DIFF
--- a/src/domain/_031_audit_log/README.md
+++ b/src/domain/_031_audit_log/README.md
@@ -1,0 +1,25 @@
+# 031 Audit Log Module
+
+This module provides the Audit Log functionality for the ERP system, allowing tracking of user actions across entities.
+
+## Features
+- Create audit logs with user and entity tracking
+- Retrieve individual audit logs or list all of them (paginated)
+- Update/Delete audit logs (CRUD completeness)
+
+## Example usage
+
+```python
+from src.domain._031_audit_log.schemas import AuditLogCreate
+from src.domain._031_audit_log.service import create_audit_log
+
+# Create a new audit log
+new_log_data = AuditLogCreate(
+    action="UPDATE",
+    entity_name="User",
+    entity_id="123",
+    user_id="admin_1",
+    details="Updated user email to admin@example.com"
+)
+audit_log = await create_audit_log(db_session, new_log_data)
+```

--- a/src/domain/_031_audit_log/__init__.py
+++ b/src/domain/_031_audit_log/__init__.py
@@ -1,0 +1,4 @@
+from .router import router
+from .models import AuditLog
+
+__all__ = ["router", "AuditLog"]

--- a/src/domain/_031_audit_log/models.py
+++ b/src/domain/_031_audit_log/models.py
@@ -1,0 +1,16 @@
+from typing import Optional
+from sqlalchemy import String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from shared.types import BaseModel
+
+
+class AuditLog(BaseModel):
+    __tablename__ = "audit_log"
+    __table_args__ = {'extend_existing': True}
+
+    action: Mapped[str] = mapped_column(String(50), nullable=False)
+    entity_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    entity_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    user_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    details: Mapped[Optional[str]] = mapped_column(Text, nullable=True)

--- a/src/domain/_031_audit_log/router.py
+++ b/src/domain/_031_audit_log/router.py
@@ -1,0 +1,65 @@
+from typing import List
+from fastapi import APIRouter, Depends, status, HTTPException
+from shared.errors import NotFoundError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.foundation._001_database import get_db
+from .schemas import AuditLogCreate, AuditLogUpdate, AuditLogResponse
+from .service import (
+    create_audit_log,
+    get_audit_log,
+    list_audit_logs,
+    update_audit_log,
+    delete_audit_log,
+)
+
+router = APIRouter(prefix="/api/v1/audit-log", tags=["Audit Log"])
+
+
+@router.post("/", response_model=AuditLogResponse, status_code=status.HTTP_201_CREATED)
+async def create_audit_log_endpoint(
+    data: AuditLogCreate, db: AsyncSession = Depends(get_db)
+):
+    """Create a new audit log entry."""
+    return await create_audit_log(db, data)
+
+
+@router.get("/{audit_log_id}", response_model=AuditLogResponse)
+async def get_audit_log_endpoint(
+    audit_log_id: int, db: AsyncSession = Depends(get_db)
+):
+    """Get an audit log entry by ID."""
+    try:
+        return await get_audit_log(db, audit_log_id)
+    except NotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+
+@router.get("/", response_model=List[AuditLogResponse])
+async def list_audit_logs_endpoint(
+    skip: int = 0, limit: int = 100, db: AsyncSession = Depends(get_db)
+):
+    """List all audit log entries."""
+    return await list_audit_logs(db, skip=skip, limit=limit)
+
+
+@router.put("/{audit_log_id}", response_model=AuditLogResponse)
+async def update_audit_log_endpoint(
+    audit_log_id: int, data: AuditLogUpdate, db: AsyncSession = Depends(get_db)
+):
+    """Update an audit log entry."""
+    try:
+        return await update_audit_log(db, audit_log_id, data)
+    except NotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+
+@router.delete("/{audit_log_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_audit_log_endpoint(
+    audit_log_id: int, db: AsyncSession = Depends(get_db)
+):
+    """Delete an audit log entry."""
+    try:
+        await delete_audit_log(db, audit_log_id)
+    except NotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))

--- a/src/domain/_031_audit_log/schemas.py
+++ b/src/domain/_031_audit_log/schemas.py
@@ -1,0 +1,30 @@
+from typing import Optional
+from datetime import datetime
+
+from shared.types import BaseSchema
+
+
+class AuditLogBase(BaseSchema):
+    action: str
+    entity_name: str
+    entity_id: str
+    user_id: str
+    details: Optional[str] = None
+
+
+class AuditLogCreate(AuditLogBase):
+    pass
+
+
+class AuditLogUpdate(BaseSchema):
+    action: Optional[str] = None
+    entity_name: Optional[str] = None
+    entity_id: Optional[str] = None
+    user_id: Optional[str] = None
+    details: Optional[str] = None
+
+
+class AuditLogResponse(AuditLogBase):
+    id: int
+    created_at: datetime
+    updated_at: datetime

--- a/src/domain/_031_audit_log/service.py
+++ b/src/domain/_031_audit_log/service.py
@@ -1,0 +1,64 @@
+from typing import List, Optional
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from shared.errors import NotFoundError
+from .models import AuditLog
+from .schemas import AuditLogCreate, AuditLogUpdate
+from .validators import validate_audit_log_create, validate_audit_log_update
+
+
+async def create_audit_log(db: AsyncSession, data: AuditLogCreate) -> AuditLog:
+    """Create a new audit log."""
+    validate_audit_log_create(data)
+
+    audit_log = AuditLog(**data.model_dump())
+    db.add(audit_log)
+    await db.commit()
+    await db.refresh(audit_log)
+    return audit_log
+
+
+async def get_audit_log(db: AsyncSession, audit_log_id: int) -> AuditLog:
+    """Get an audit log by ID."""
+    query = select(AuditLog).where(AuditLog.id == audit_log_id)
+    result = await db.execute(query)
+    audit_log = result.scalar_one_or_none()
+
+    if not audit_log:
+        raise NotFoundError(f"Audit log with ID {audit_log_id} not found")
+
+    return audit_log
+
+
+async def list_audit_logs(
+    db: AsyncSession, skip: int = 0, limit: int = 100
+) -> List[AuditLog]:
+    """List all audit logs with pagination."""
+    query = select(AuditLog).offset(skip).limit(limit)
+    result = await db.execute(query)
+    return list(result.scalars().all())
+
+
+async def update_audit_log(
+    db: AsyncSession, audit_log_id: int, data: AuditLogUpdate
+) -> AuditLog:
+    """Update an existing audit log."""
+    validate_audit_log_update(data)
+
+    audit_log = await get_audit_log(db, audit_log_id)
+
+    update_data = data.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(audit_log, key, value)
+
+    await db.commit()
+    await db.refresh(audit_log)
+    return audit_log
+
+
+async def delete_audit_log(db: AsyncSession, audit_log_id: int) -> None:
+    """Delete an audit log by ID."""
+    audit_log = await get_audit_log(db, audit_log_id)
+    await db.delete(audit_log)
+    await db.commit()

--- a/src/domain/_031_audit_log/tests/test_models.py
+++ b/src/domain/_031_audit_log/tests/test_models.py
@@ -1,0 +1,36 @@
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from src.domain._031_audit_log.models import AuditLog
+from src.foundation._001_database.engine import create_engine, get_session_factory
+from shared.types import Base
+
+@pytest.fixture
+async def db_session():
+    test_engine = create_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_factory = get_session_factory(test_engine)
+    async with session_factory() as session:
+        yield session
+
+@pytest.mark.asyncio
+async def test_audit_log_model(db_session: AsyncSession):
+    audit_log = AuditLog(
+        action="CREATE",
+        entity_name="User",
+        entity_id="user_123",
+        user_id="admin_1",
+        details="User created"
+    )
+    db_session.add(audit_log)
+    await db_session.commit()
+    await db_session.refresh(audit_log)
+
+    assert audit_log.id is not None
+    assert audit_log.action == "CREATE"
+    assert audit_log.entity_name == "User"
+    assert audit_log.entity_id == "user_123"
+    assert audit_log.user_id == "admin_1"
+    assert audit_log.details == "User created"
+    assert audit_log.created_at is not None
+    assert audit_log.updated_at is not None

--- a/src/domain/_031_audit_log/tests/test_router.py
+++ b/src/domain/_031_audit_log/tests/test_router.py
@@ -1,0 +1,71 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from fastapi import FastAPI
+from src.domain._031_audit_log.router import router
+from src.foundation._001_database.engine import create_engine, get_session_factory, get_db
+from shared.types import Base
+
+@pytest.fixture
+async def db_session():
+    test_engine = create_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_factory = get_session_factory(test_engine)
+    async with session_factory() as session:
+        yield session
+
+@pytest.fixture
+def app(db_session):
+    app = FastAPI()
+    app.include_router(router)
+
+    async def override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+    return app
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+@pytest.mark.asyncio
+async def test_router_audit_log(client: AsyncClient):
+    # Create
+    create_data = {
+        "action": "CREATE",
+        "entity_name": "Invoice",
+        "entity_id": "inv_1",
+        "user_id": "user_1"
+    }
+    response = await client.post("/api/v1/audit-log/", json=create_data)
+    assert response.status_code == 201
+    data = response.json()
+    assert data["action"] == "CREATE"
+    audit_log_id = data["id"]
+
+    # Get
+    response = await client.get(f"/api/v1/audit-log/{audit_log_id}")
+    assert response.status_code == 200
+    assert response.json()["id"] == audit_log_id
+
+    # List
+    response = await client.get("/api/v1/audit-log/")
+    assert response.status_code == 200
+    assert len(response.json()) >= 1
+
+    # Update
+    update_data = {"action": "UPDATE"}
+    response = await client.put(f"/api/v1/audit-log/{audit_log_id}", json=update_data)
+    assert response.status_code == 200
+    assert response.json()["action"] == "UPDATE"
+
+    # Delete
+    response = await client.delete(f"/api/v1/audit-log/{audit_log_id}")
+    assert response.status_code == 204
+
+    # Verify deletion
+    response = await client.get(f"/api/v1/audit-log/{audit_log_id}")
+    assert response.status_code == 404

--- a/src/domain/_031_audit_log/tests/test_service.py
+++ b/src/domain/_031_audit_log/tests/test_service.py
@@ -1,0 +1,53 @@
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from src.domain._031_audit_log.schemas import AuditLogCreate, AuditLogUpdate
+from src.domain._031_audit_log.service import (
+    create_audit_log,
+    get_audit_log,
+    list_audit_logs,
+    update_audit_log,
+    delete_audit_log,
+)
+from shared.errors import NotFoundError
+from src.foundation._001_database.engine import create_engine, get_session_factory
+from shared.types import Base
+
+@pytest.fixture
+async def db_session():
+    test_engine = create_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_factory = get_session_factory(test_engine)
+    async with session_factory() as session:
+        yield session
+
+@pytest.mark.asyncio
+async def test_crud_audit_log(db_session: AsyncSession):
+    # Create
+    create_data = AuditLogCreate(
+        action="CREATE",
+        entity_name="Order",
+        entity_id="ord_1",
+        user_id="user_2"
+    )
+    audit_log = await create_audit_log(db_session, create_data)
+    assert audit_log.id is not None
+    assert audit_log.action == "CREATE"
+
+    # Get
+    fetched_log = await get_audit_log(db_session, audit_log.id)
+    assert fetched_log.id == audit_log.id
+
+    # List
+    logs = await list_audit_logs(db_session)
+    assert len(logs) >= 1
+
+    # Update
+    update_data = AuditLogUpdate(action="UPDATE")
+    updated_log = await update_audit_log(db_session, audit_log.id, update_data)
+    assert updated_log.action == "UPDATE"
+
+    # Delete
+    await delete_audit_log(db_session, audit_log.id)
+    with pytest.raises(NotFoundError):
+        await get_audit_log(db_session, audit_log.id)

--- a/src/domain/_031_audit_log/tests/test_validators.py
+++ b/src/domain/_031_audit_log/tests/test_validators.py
@@ -1,0 +1,32 @@
+import pytest
+from src.domain._031_audit_log.schemas import AuditLogCreate, AuditLogUpdate
+from src.domain._031_audit_log.validators import validate_audit_log_create, validate_audit_log_update
+from shared.errors import ValidationError
+
+def test_validate_audit_log_create_valid():
+    data = AuditLogCreate(
+        action="UPDATE",
+        entity_name="Product",
+        entity_id="prod_1",
+        user_id="user_1"
+    )
+    # Should not raise
+    validate_audit_log_create(data)
+
+def test_validate_audit_log_create_invalid():
+    with pytest.raises(ValidationError):
+        validate_audit_log_create(AuditLogCreate(
+            action="",
+            entity_name="Product",
+            entity_id="prod_1",
+            user_id="user_1"
+        ))
+
+def test_validate_audit_log_update_valid():
+    data = AuditLogUpdate(action="DELETE")
+    # Should not raise
+    validate_audit_log_update(data)
+
+def test_validate_audit_log_update_invalid():
+    with pytest.raises(ValidationError):
+        validate_audit_log_update(AuditLogUpdate(action="  "))

--- a/src/domain/_031_audit_log/validators.py
+++ b/src/domain/_031_audit_log/validators.py
@@ -1,0 +1,22 @@
+from shared.errors import ValidationError
+from .schemas import AuditLogCreate, AuditLogUpdate
+
+def validate_audit_log_create(data: AuditLogCreate) -> None:
+    if not data.action.strip():
+        raise ValidationError("Action cannot be empty.")
+    if not data.entity_name.strip():
+        raise ValidationError("Entity name cannot be empty.")
+    if not data.entity_id.strip():
+        raise ValidationError("Entity ID cannot be empty.")
+    if not data.user_id.strip():
+        raise ValidationError("User ID cannot be empty.")
+
+def validate_audit_log_update(data: AuditLogUpdate) -> None:
+    if data.action is not None and not data.action.strip():
+        raise ValidationError("Action cannot be empty if provided.")
+    if data.entity_name is not None and not data.entity_name.strip():
+        raise ValidationError("Entity name cannot be empty if provided.")
+    if data.entity_id is not None and not data.entity_id.strip():
+        raise ValidationError("Entity ID cannot be empty if provided.")
+    if data.user_id is not None and not data.user_id.strip():
+        raise ValidationError("User ID cannot be empty if provided.")


### PR DESCRIPTION
Implements the Issue 31 functional requirements: a full FastAPI, SQLAlchemy, and Pydantic CRUD module for tracking audit logs (`_031_audit_log`).

---
*PR created automatically by Jules for task [1959184215785640054](https://jules.google.com/task/1959184215785640054) started by @muumuu8181*